### PR TITLE
Allow uncentered title if chkDisplayGameIcon is unchecked

### DIFF
--- a/UI/Components/AlignmentType.cs
+++ b/UI/Components/AlignmentType.cs
@@ -1,0 +1,9 @@
+﻿namespace LiveSplit.UI.Components
+{
+    public enum AlignmentType
+    {
+        Auto = 0,
+        Left = 1,
+        Center = 2
+    }
+}

--- a/UI/Components/Title.cs
+++ b/UI/Components/Title.cs
@@ -119,7 +119,7 @@ namespace LiveSplit.UI.Components
 
         private void DrawCategoryName(Graphics g, LiveSplitState state, float width, float height, bool showGameIcon, float startPadding, float categoryEndPadding)
         {
-            if (Settings.CenterTitle || !showGameIcon)
+            if (Settings.CenterTitle)
             {
                 CategoryNameLabel.CalculateAlternateText(g, width - startPadding - categoryEndPadding);
                 float stringWidth = CategoryNameLabel.ActualWidth;
@@ -165,7 +165,7 @@ namespace LiveSplit.UI.Components
 
         private void DrawGameName(Graphics g, LiveSplitState state, float width, float height, bool showGameIcon, float startPadding, float titleEndPadding)
         {
-            if (Settings.CenterTitle || !showGameIcon)
+            if (Settings.CenterTitle)
             {
                 GameNameLabel.CalculateAlternateText(g, width - startPadding - titleEndPadding);
                 float stringWidth = GameNameLabel.ActualWidth;

--- a/UI/Components/Title.cs
+++ b/UI/Components/Title.cs
@@ -119,7 +119,7 @@ namespace LiveSplit.UI.Components
 
         private void DrawCategoryName(Graphics g, LiveSplitState state, float width, float height, bool showGameIcon, float startPadding, float categoryEndPadding)
         {
-            if (Settings.CenterTitle)
+            if (Settings.TextAlignment == AlignmentType.Center || (Settings.TextAlignment == AlignmentType.Auto && !showGameIcon))
             {
                 CategoryNameLabel.CalculateAlternateText(g, width - startPadding - categoryEndPadding);
                 float stringWidth = CategoryNameLabel.ActualWidth;
@@ -165,7 +165,7 @@ namespace LiveSplit.UI.Components
 
         private void DrawGameName(Graphics g, LiveSplitState state, float width, float height, bool showGameIcon, float startPadding, float titleEndPadding)
         {
-            if (Settings.CenterTitle)
+            if (Settings.TextAlignment == AlignmentType.Center || (Settings.TextAlignment == AlignmentType.Auto && !showGameIcon))
             {
                 GameNameLabel.CalculateAlternateText(g, width - startPadding - titleEndPadding);
                 float stringWidth = GameNameLabel.ActualWidth;
@@ -386,6 +386,7 @@ namespace LiveSplit.UI.Components
             Cache["GameNameLabel"] = GameNameLabel.Text;
             Cache["CategoryNameLabel"] = CategoryNameLabel.Text;
             Cache["AttemptCountLabel"] = AttemptCountLabel.Text;
+            Cache["TextAlignment"] = Settings.TextAlignment;
 
             if (invalidator != null && (Cache.HasChanged || FrameCount > 1))
             {

--- a/UI/Components/TitleFactory.cs
+++ b/UI/Components/TitleFactory.cs
@@ -19,6 +19,6 @@ namespace LiveSplit.UI.Components
 
         public string UpdateURL => "http://livesplit.org/update/";
 
-        public Version Version => Version.Parse("1.7.2");
+        public Version Version => Version.Parse("1.7.3");
     }
 }

--- a/UI/Components/TitleSettings.Designer.cs
+++ b/UI/Components/TitleSettings.Designer.cs
@@ -356,7 +356,6 @@
             this.chkDisplayGameIcon.TabIndex = 7;
             this.chkDisplayGameIcon.Text = "Display Game Icon";
             this.chkDisplayGameIcon.UseVisualStyleBackColor = true;
-            this.chkDisplayGameIcon.CheckedChanged += new System.EventHandler(this.chkDisplayGameIcon_CheckedChanged);
             // 
             // groupBox3
             // 

--- a/UI/Components/TitleSettings.Designer.cs
+++ b/UI/Components/TitleSettings.Designer.cs
@@ -29,6 +29,8 @@
         private void InitializeComponent()
         {
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.chkCategoryName = new System.Windows.Forms.CheckBox();
+            this.chkGameName = new System.Windows.Forms.CheckBox();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
             this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
             this.chkColor = new System.Windows.Forms.CheckBox();
@@ -46,16 +48,15 @@
             this.btnColor2 = new System.Windows.Forms.Button();
             this.chkAttemptCount = new System.Windows.Forms.CheckBox();
             this.chkFinishedRuns = new System.Windows.Forms.CheckBox();
-            this.chkSingleLine = new System.Windows.Forms.CheckBox();
-            this.chkCenter = new System.Windows.Forms.CheckBox();
             this.chkDisplayGameIcon = new System.Windows.Forms.CheckBox();
             this.groupBox3 = new System.Windows.Forms.GroupBox();
             this.tableLayoutPanel4 = new System.Windows.Forms.TableLayoutPanel();
             this.chkVariables = new System.Windows.Forms.CheckBox();
             this.chkPlatform = new System.Windows.Forms.CheckBox();
             this.chkRegion = new System.Windows.Forms.CheckBox();
-            this.chkGameName = new System.Windows.Forms.CheckBox();
-            this.chkCategoryName = new System.Windows.Forms.CheckBox();
+            this.chkSingleLine = new System.Windows.Forms.CheckBox();
+            this.label2 = new System.Windows.Forms.Label();
+            this.cmbTextAlignment = new System.Windows.Forms.ComboBox();
             this.tableLayoutPanel1.SuspendLayout();
             this.groupBox2.SuspendLayout();
             this.tableLayoutPanel3.SuspendLayout();
@@ -82,10 +83,11 @@
             this.tableLayoutPanel1.Controls.Add(this.btnColor2, 2, 0);
             this.tableLayoutPanel1.Controls.Add(this.chkAttemptCount, 3, 4);
             this.tableLayoutPanel1.Controls.Add(this.chkFinishedRuns, 0, 4);
-            this.tableLayoutPanel1.Controls.Add(this.chkSingleLine, 0, 6);
-            this.tableLayoutPanel1.Controls.Add(this.chkCenter, 3, 5);
             this.tableLayoutPanel1.Controls.Add(this.chkDisplayGameIcon, 0, 5);
             this.tableLayoutPanel1.Controls.Add(this.groupBox3, 0, 7);
+            this.tableLayoutPanel1.Controls.Add(this.chkSingleLine, 3, 5);
+            this.tableLayoutPanel1.Controls.Add(this.label2, 0, 6);
+            this.tableLayoutPanel1.Controls.Add(this.cmbTextAlignment, 1, 6);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel1.Location = new System.Drawing.Point(7, 7);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
@@ -96,11 +98,35 @@
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 34F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
             this.tableLayoutPanel1.Size = new System.Drawing.Size(462, 393);
             this.tableLayoutPanel1.TabIndex = 0;
+            // 
+            // chkCategoryName
+            // 
+            this.chkCategoryName.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.chkCategoryName.AutoSize = true;
+            this.chkCategoryName.Location = new System.Drawing.Point(216, 199);
+            this.chkCategoryName.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
+            this.chkCategoryName.Name = "chkCategoryName";
+            this.chkCategoryName.Size = new System.Drawing.Size(243, 17);
+            this.chkCategoryName.TabIndex = 43;
+            this.chkCategoryName.Text = "Show Category Name";
+            this.chkCategoryName.UseVisualStyleBackColor = true;
+            // 
+            // chkGameName
+            // 
+            this.chkGameName.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.chkGameName.AutoSize = true;
+            this.tableLayoutPanel1.SetColumnSpan(this.chkGameName, 3);
+            this.chkGameName.Location = new System.Drawing.Point(7, 199);
+            this.chkGameName.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
+            this.chkGameName.Name = "chkGameName";
+            this.chkGameName.Size = new System.Drawing.Size(199, 17);
+            this.chkGameName.TabIndex = 42;
+            this.chkGameName.Text = "Show Game Name";
+            this.chkGameName.UseVisualStyleBackColor = true;
             // 
             // groupBox2
             // 
@@ -320,31 +346,6 @@
             this.chkFinishedRuns.Text = "Show Finished Runs Count";
             this.chkFinishedRuns.UseVisualStyleBackColor = true;
             // 
-            // chkSingleLine
-            // 
-            this.chkSingleLine.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.chkSingleLine.AutoSize = true;
-            this.tableLayoutPanel1.SetColumnSpan(this.chkSingleLine, 4);
-            this.chkSingleLine.Location = new System.Drawing.Point(7, 286);
-            this.chkSingleLine.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
-            this.chkSingleLine.Name = "chkSingleLine";
-            this.chkSingleLine.Size = new System.Drawing.Size(452, 17);
-            this.chkSingleLine.TabIndex = 40;
-            this.chkSingleLine.Text = "Display Game and Category in Single Line";
-            this.chkSingleLine.UseVisualStyleBackColor = true;
-            // 
-            // chkCenter
-            // 
-            this.chkCenter.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.chkCenter.AutoSize = true;
-            this.chkCenter.Location = new System.Drawing.Point(216, 257);
-            this.chkCenter.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
-            this.chkCenter.Name = "chkCenter";
-            this.chkCenter.Size = new System.Drawing.Size(243, 17);
-            this.chkCenter.TabIndex = 8;
-            this.chkCenter.Text = "Center Text";
-            this.chkCenter.UseVisualStyleBackColor = true;
-            // 
             // chkDisplayGameIcon
             // 
             this.chkDisplayGameIcon.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
@@ -362,9 +363,9 @@
             this.tableLayoutPanel1.SetColumnSpan(this.groupBox3, 4);
             this.groupBox3.Controls.Add(this.tableLayoutPanel4);
             this.groupBox3.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.groupBox3.Location = new System.Drawing.Point(3, 312);
+            this.groupBox3.Location = new System.Drawing.Point(3, 317);
             this.groupBox3.Name = "groupBox3";
-            this.groupBox3.Size = new System.Drawing.Size(456, 78);
+            this.groupBox3.Size = new System.Drawing.Size(456, 73);
             this.groupBox3.TabIndex = 41;
             this.groupBox3.TabStop = false;
             this.groupBox3.Text = "Additional Category Info";
@@ -383,7 +384,7 @@
             this.tableLayoutPanel4.RowCount = 2;
             this.tableLayoutPanel4.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
             this.tableLayoutPanel4.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel4.Size = new System.Drawing.Size(450, 59);
+            this.tableLayoutPanel4.Size = new System.Drawing.Size(450, 54);
             this.tableLayoutPanel4.TabIndex = 0;
             // 
             // chkVariables
@@ -422,30 +423,43 @@
             this.chkRegion.Text = "Show Region";
             this.chkRegion.UseVisualStyleBackColor = true;
             // 
-            // chkGameName
+            // chkSingleLine
             // 
-            this.chkGameName.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.chkGameName.AutoSize = true;
-            this.tableLayoutPanel1.SetColumnSpan(this.chkGameName, 3);
-            this.chkGameName.Location = new System.Drawing.Point(7, 199);
-            this.chkGameName.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
-            this.chkGameName.Name = "chkGameName";
-            this.chkGameName.Size = new System.Drawing.Size(199, 17);
-            this.chkGameName.TabIndex = 42;
-            this.chkGameName.Text = "Show Game Name";
-            this.chkGameName.UseVisualStyleBackColor = true;
+            this.chkSingleLine.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.chkSingleLine.AutoSize = true;
+            this.chkSingleLine.Location = new System.Drawing.Point(216, 257);
+            this.chkSingleLine.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
+            this.chkSingleLine.Name = "chkSingleLine";
+            this.chkSingleLine.Size = new System.Drawing.Size(243, 17);
+            this.chkSingleLine.TabIndex = 40;
+            this.chkSingleLine.Text = "Display Game and Category in Single Line";
+            this.chkSingleLine.UseVisualStyleBackColor = true;
             // 
-            // chkCategoryName
+            // label2
             // 
-            this.chkCategoryName.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.chkCategoryName.AutoSize = true;
-            this.chkCategoryName.Location = new System.Drawing.Point(216, 199);
-            this.chkCategoryName.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
-            this.chkCategoryName.Name = "chkCategoryName";
-            this.chkCategoryName.Size = new System.Drawing.Size(243, 17);
-            this.chkCategoryName.TabIndex = 43;
-            this.chkCategoryName.Text = "Show Category Name";
-            this.chkCategoryName.UseVisualStyleBackColor = true;
+            this.label2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(3, 290);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(145, 13);
+            this.label2.TabIndex = 44;
+            this.label2.Text = "Text Alignment:";
+            // 
+            // cmbTextAlignment
+            // 
+            this.cmbTextAlignment.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.tableLayoutPanel1.SetColumnSpan(this.cmbTextAlignment, 3);
+            this.cmbTextAlignment.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbTextAlignment.FormattingEnabled = true;
+            this.cmbTextAlignment.Items.AddRange(new object[] {
+            "Automatic (Based on Icon)",
+            "Left",
+            "Center"});
+            this.cmbTextAlignment.Location = new System.Drawing.Point(154, 286);
+            this.cmbTextAlignment.Name = "cmbTextAlignment";
+            this.cmbTextAlignment.Size = new System.Drawing.Size(305, 21);
+            this.cmbTextAlignment.TabIndex = 45;
+            this.cmbTextAlignment.SelectedIndexChanged += new System.EventHandler(this.cmbTextAlignment_SelectedIndexChanged);
             // 
             // TitleSettings
             // 
@@ -492,7 +506,6 @@
         private System.Windows.Forms.Button btnColor2;
         private System.Windows.Forms.CheckBox chkDisplayGameIcon;
         private System.Windows.Forms.CheckBox chkFinishedRuns;
-        private System.Windows.Forms.CheckBox chkCenter;
         private System.Windows.Forms.CheckBox chkSingleLine;
         private System.Windows.Forms.GroupBox groupBox3;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel4;
@@ -501,5 +514,7 @@
         private System.Windows.Forms.CheckBox chkRegion;
         private System.Windows.Forms.CheckBox chkCategoryName;
         private System.Windows.Forms.CheckBox chkGameName;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.ComboBox cmbTextAlignment;
     }
 }

--- a/UI/Components/TitleSettings.cs
+++ b/UI/Components/TitleSettings.cs
@@ -70,6 +70,7 @@ namespace LiveSplit.UI.Components
             btnColor1.DataBindings.Add("BackColor", this, "BackgroundColor", false, DataSourceUpdateMode.OnPropertyChanged);
             btnColor2.DataBindings.Add("BackColor", this, "BackgroundColor2", false, DataSourceUpdateMode.OnPropertyChanged);
             chkDisplayGameIcon.DataBindings.Add("Checked", this, "DisplayGameIcon", false, DataSourceUpdateMode.OnPropertyChanged);
+            chkCenter.DataBindings.Add("Checked", this, "CenterTitle", false, DataSourceUpdateMode.OnPropertyChanged);
             cmbGradientType.DataBindings.Add("SelectedItem", this, "GradientString", false, DataSourceUpdateMode.OnPropertyChanged);
             chkRegion.DataBindings.Add("Checked", this, "ShowRegion", false, DataSourceUpdateMode.OnPropertyChanged);
             chkPlatform.DataBindings.Add("Checked", this, "ShowPlatform", false, DataSourceUpdateMode.OnPropertyChanged);
@@ -80,7 +81,6 @@ namespace LiveSplit.UI.Components
         {
             chkColor_CheckedChanged(null, null);
             chkFont_CheckedChanged(null, null);
-            chkDisplayGameIcon_CheckedChanged(null, null);
         }
 
         void chkColor_CheckedChanged(object sender, EventArgs e)
@@ -105,12 +105,19 @@ namespace LiveSplit.UI.Components
         {
             var element = (XmlElement)node;
             Version version = SettingsHelper.ParseVersion(element["Version"]);
+            DisplayGameIcon = SettingsHelper.ParseBool(element["DisplayGameIcon"], true);
 
             if (version >= new Version(1, 2))
             {
                 TitleFont = SettingsHelper.GetFontFromElement(element["TitleFont"]);
                 if (version >= new Version(1, 3))
+                {
                     OverrideTitleFont = SettingsHelper.ParseBool(element["OverrideTitleFont"]);
+                    if (version <= new Version(1, 8) && !DisplayGameIcon)
+                        CenterTitle = true;
+                    else
+                        CenterTitle = SettingsHelper.ParseBool(element["CenterTitle"], false);
+                }
                 else
                     OverrideTitleFont = !SettingsHelper.ParseBool(element["UseLayoutSettingsFont"]);
             }
@@ -128,9 +135,7 @@ namespace LiveSplit.UI.Components
             BackgroundColor = SettingsHelper.ParseColor(element["BackgroundColor"], Color.FromArgb(42, 42, 42, 255));
             BackgroundColor2 = SettingsHelper.ParseColor(element["BackgroundColor2"], Color.FromArgb(19, 19, 19, 255));
             GradientString = SettingsHelper.ParseString(element["BackgroundGradient"], GradientType.Vertical.ToString());
-            DisplayGameIcon = SettingsHelper.ParseBool(element["DisplayGameIcon"], true);
             ShowFinishedRunsCount = SettingsHelper.ParseBool(element["ShowFinishedRunsCount"], false);
-            CenterTitle = SettingsHelper.ParseBool(element["CenterTitle"], false);
             SingleLine = SettingsHelper.ParseBool(element["SingleLine"], false);
             ShowRegion = SettingsHelper.ParseBool(element["ShowRegion"], false);
             ShowPlatform = SettingsHelper.ParseBool(element["ShowPlatform"], false);
@@ -148,7 +153,7 @@ namespace LiveSplit.UI.Components
 
         private int CreateSettingsNode(XmlDocument document, XmlElement parent)
         {
-            return SettingsHelper.CreateSetting(document, parent, "Version", "1.7") ^
+            return SettingsHelper.CreateSetting(document, parent, "Version", "1.8.0") ^
             SettingsHelper.CreateSetting(document, parent, "ShowGameName", ShowGameName) ^
             SettingsHelper.CreateSetting(document, parent, "ShowCategoryName", ShowCategoryName) ^
             SettingsHelper.CreateSetting(document, parent, "ShowAttemptCount", ShowAttemptCount) ^
@@ -179,22 +184,6 @@ namespace LiveSplit.UI.Components
         private void ColorButtonClick(object sender, EventArgs e)
         {
             SettingsHelper.ColorButtonClick((Button)sender, this);
-        }
-
-        private void chkDisplayGameIcon_CheckedChanged(object sender, EventArgs e)
-        {
-            if (chkDisplayGameIcon.Checked)
-            {
-                chkCenter.Enabled = true;
-                chkCenter.DataBindings.Clear();
-                chkCenter.DataBindings.Add("Checked", this, "CenterTitle", false, DataSourceUpdateMode.OnPropertyChanged);
-            }
-            else
-            {
-                chkCenter.Enabled = false;
-                chkCenter.DataBindings.Clear();
-                chkCenter.Checked = true;
-            }
         }
     }
 }

--- a/UI/Components/TitleSettings.cs
+++ b/UI/Components/TitleSettings.cs
@@ -12,7 +12,7 @@ namespace LiveSplit.UI.Components
         public bool ShowAttemptCount { get; set; }
         public bool ShowFinishedRunsCount { get; set; }
         public bool ShowCount => ShowAttemptCount || ShowFinishedRunsCount;
-        public bool CenterTitle { get; set; }
+        public AlignmentType TextAlignment { get; set; }
         public bool SingleLine { get; set; }
         public bool DisplayGameIcon { get; set; }
 
@@ -49,7 +49,6 @@ namespace LiveSplit.UI.Components
             OverrideTitleFont = false;
             TitleColor = Color.FromArgb(255, 255, 255, 255);
             OverrideTitleColor = false;
-            CenterTitle = false;
             SingleLine = false;
             ShowRegion = false;
             ShowPlatform = false;
@@ -57,6 +56,7 @@ namespace LiveSplit.UI.Components
             BackgroundColor = Color.FromArgb(255, 42, 42, 42);
             BackgroundColor2 = Color.FromArgb(255, 19, 19, 19);
             BackgroundGradient = GradientType.Vertical;
+            TextAlignment = AlignmentType.Auto;
 
             chkGameName.DataBindings.Add("Checked", this, "ShowGameName", false, DataSourceUpdateMode.OnPropertyChanged);
             chkCategoryName.DataBindings.Add("Checked", this, "ShowCategoryName", false, DataSourceUpdateMode.OnPropertyChanged);
@@ -70,7 +70,6 @@ namespace LiveSplit.UI.Components
             btnColor1.DataBindings.Add("BackColor", this, "BackgroundColor", false, DataSourceUpdateMode.OnPropertyChanged);
             btnColor2.DataBindings.Add("BackColor", this, "BackgroundColor2", false, DataSourceUpdateMode.OnPropertyChanged);
             chkDisplayGameIcon.DataBindings.Add("Checked", this, "DisplayGameIcon", false, DataSourceUpdateMode.OnPropertyChanged);
-            chkCenter.DataBindings.Add("Checked", this, "CenterTitle", false, DataSourceUpdateMode.OnPropertyChanged);
             cmbGradientType.DataBindings.Add("SelectedItem", this, "GradientString", false, DataSourceUpdateMode.OnPropertyChanged);
             chkRegion.DataBindings.Add("Checked", this, "ShowRegion", false, DataSourceUpdateMode.OnPropertyChanged);
             chkPlatform.DataBindings.Add("Checked", this, "ShowPlatform", false, DataSourceUpdateMode.OnPropertyChanged);
@@ -81,6 +80,7 @@ namespace LiveSplit.UI.Components
         {
             chkColor_CheckedChanged(null, null);
             chkFont_CheckedChanged(null, null);
+            cmbTextAlignment.SelectedIndex = (int)TextAlignment;
         }
 
         void chkColor_CheckedChanged(object sender, EventArgs e)
@@ -101,6 +101,11 @@ namespace LiveSplit.UI.Components
             GradientString = cmbGradientType.SelectedItem.ToString();
         }
 
+        void cmbTextAlignment_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            TextAlignment = (AlignmentType)cmbTextAlignment.SelectedIndex;
+        }
+
         public void SetSettings(XmlNode node)
         {
             var element = (XmlElement)node;
@@ -113,10 +118,17 @@ namespace LiveSplit.UI.Components
                 if (version >= new Version(1, 3))
                 {
                     OverrideTitleFont = SettingsHelper.ParseBool(element["OverrideTitleFont"]);
-                    if (version < new Version(1, 7, 3) && !DisplayGameIcon)
-                        CenterTitle = true;
+                    if (version >= new Version(1, 7, 3))
+                    {
+                        TextAlignment = (AlignmentType)SettingsHelper.ParseInt(element["TextAlignment"], 0);
+                    }
                     else
-                        CenterTitle = SettingsHelper.ParseBool(element["CenterTitle"], false);
+                    {
+                        if (DisplayGameIcon && SettingsHelper.ParseBool(element["CenterTitle"], false))
+                            TextAlignment = AlignmentType.Center;
+                        else
+                            TextAlignment = AlignmentType.Auto;
+                    }
                 }
                 else
                     OverrideTitleFont = !SettingsHelper.ParseBool(element["UseLayoutSettingsFont"]);
@@ -161,7 +173,6 @@ namespace LiveSplit.UI.Components
             SettingsHelper.CreateSetting(document, parent, "OverrideTitleFont", OverrideTitleFont) ^
             SettingsHelper.CreateSetting(document, parent, "OverrideTitleColor", OverrideTitleColor) ^
             SettingsHelper.CreateSetting(document, parent, "TitleFont", TitleFont) ^
-            SettingsHelper.CreateSetting(document, parent, "CenterTitle", CenterTitle) ^
             SettingsHelper.CreateSetting(document, parent, "SingleLine", SingleLine) ^
             SettingsHelper.CreateSetting(document, parent, "TitleColor", TitleColor) ^
             SettingsHelper.CreateSetting(document, parent, "BackgroundColor", BackgroundColor) ^
@@ -170,7 +181,8 @@ namespace LiveSplit.UI.Components
             SettingsHelper.CreateSetting(document, parent, "DisplayGameIcon", DisplayGameIcon) ^
             SettingsHelper.CreateSetting(document, parent, "ShowRegion", ShowRegion) ^
             SettingsHelper.CreateSetting(document, parent, "ShowPlatform", ShowPlatform) ^
-            SettingsHelper.CreateSetting(document, parent, "ShowVariables", ShowVariables);
+            SettingsHelper.CreateSetting(document, parent, "ShowVariables", ShowVariables) ^
+            SettingsHelper.CreateSetting(document, parent, "TextAlignment", (int)TextAlignment);
         }
 
         private void btnFont_Click(object sender, EventArgs e)

--- a/UI/Components/TitleSettings.cs
+++ b/UI/Components/TitleSettings.cs
@@ -113,7 +113,7 @@ namespace LiveSplit.UI.Components
                 if (version >= new Version(1, 3))
                 {
                     OverrideTitleFont = SettingsHelper.ParseBool(element["OverrideTitleFont"]);
-                    if (version <= new Version(1, 8) && !DisplayGameIcon)
+                    if (version < new Version(1, 7, 3) && !DisplayGameIcon)
                         CenterTitle = true;
                     else
                         CenterTitle = SettingsHelper.ParseBool(element["CenterTitle"], false);
@@ -153,7 +153,7 @@ namespace LiveSplit.UI.Components
 
         private int CreateSettingsNode(XmlDocument document, XmlElement parent)
         {
-            return SettingsHelper.CreateSetting(document, parent, "Version", "1.8.0") ^
+            return SettingsHelper.CreateSetting(document, parent, "Version", "1.7.3") ^
             SettingsHelper.CreateSetting(document, parent, "ShowGameName", ShowGameName) ^
             SettingsHelper.CreateSetting(document, parent, "ShowCategoryName", ShowCategoryName) ^
             SettingsHelper.CreateSetting(document, parent, "ShowAttemptCount", ShowAttemptCount) ^


### PR DESCRIPTION
https://github.com/LiveSplit/LiveSplit.Title/commit/fcaeb745f5ae613ce617a23f9054627575a2b46c took away the option to have uncentered text if the game icon isn't displayed.

However, especially in combination with the attempt count it sometimes looks better if the text isn't centered, since most other components show some description on the left side and its value on the right side. It's not a highly requested feature but the option is already there, you just can't use it.

Note about the version checks: 1.7.2 doesn't update `CenterTitle` when unchecking `chkDisplayGameIcon`, therefore `<CenterTitle></CenterTitle>` can be false in the lsl even though it's centered without the icon.