### PR TITLE
Introduce use of `Directory.Build.props`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .fleet/
 
 # Build artifacts
+artifacts/
 bin/
 obj/
 publish/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,24 @@
+<Project>
+
+  <!-- Imports `Directory.Build.props` from the above directory, if it exists. -->
+  <!-- If it does not, the properties `LsSrcPath`, `LsLibPath`, and `ComponentsDir` must be provided via the command line. -->
+  <!-- Example: `dotnet build -p:LsSrcPath=path/to/LiveSplit/src` -->
+
+  <Import Project="..\Directory.Build.props"
+          Condition="Exists('..\Directory.Build.props')" />
+
+  <PropertyGroup Label="Project Settings">
+    <TargetFramework>net4.6.1</TargetFramework>
+
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Common Directories">
+    <RootPath>$(MSBuildThisFileDirectory)</RootPath>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Output Settings">
+    <UseArtifactsOutput>true</UseArtifactsOutput>
+  </PropertyGroup>
+
+</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,6 +15,9 @@
 
   <PropertyGroup Label="Common Directories">
     <RootPath>$(MSBuildThisFileDirectory)</RootPath>
+
+    <SrcPath>$(RootPath)\src</SrcPath>
+    <TestPath>$(RootPath)\test</TestPath>
   </PropertyGroup>
 
   <PropertyGroup Label="Output Settings">

--- a/src/LiveSplit.Title/LiveSplit.Title.csproj
+++ b/src/LiveSplit.Title/LiveSplit.Title.csproj
@@ -1,13 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutDir>..\..\..\..\bin\$(Configuration)\Components</OutDir>
     <RootNamespace>LiveSplit</RootNamespace>
-    <TargetFramework>net4.6.1</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
 
     <EnableDynamicLoading>true</EnableDynamicLoading>
-    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/LiveSplit.Title/LiveSplit.Title.csproj
+++ b/src/LiveSplit.Title/LiveSplit.Title.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\LiveSplit.Core\LiveSplit.Core.csproj" Private="false" ExcludeAssets="runtime" />
-    <ProjectReference Include="..\..\..\..\src\UpdateManager\UpdateManager.csproj" Private="false" ExcludeAssets="runtime" />
-    <ProjectReference Include="..\..\..\..\lib\CustomFontDialog\CustomFontDialog\CustomFontDialog.csproj" Private="false" ExcludeAssets="runtime" />
+    <ProjectReference Include="$(LsSrcPath)\LiveSplit.Core\LiveSplit.Core.csproj" Private="false" ExcludeAssets="runtime" />
+    <ProjectReference Include="$(LsSrcPath)\UpdateManager\UpdateManager.csproj" Private="false" ExcludeAssets="runtime" />
+    <ProjectReference Include="$(LsLibPath)\CustomFontDialog\CustomFontDialog\CustomFontDialog.csproj" Private="false" ExcludeAssets="runtime" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Parent PR is https://github.com/LiveSplit/LiveSplit/pull/2482.

### Description

Adds a `Directory.Build.props` file to the root of the repository. It provides common properties to all projects in all (recursive) sub-directories.  
This is a component, normally included via `LiveSplit/LiveSplit`. The changes in this PR attempt to allow for the component to be built even outside of the file structure of the parent repo.

To build, the paths to the parent repo need to be provided as such: `dotnet build -p:LsSrcPath=path/to/LiveSplit/src`. If built from within `LiveSplit/LiveSplit`, these are provided by the `Directory.Build.props` contained in `LiveSplit/LiveSplit/components`. This file is conditionally included in the `Directory.Build.props` file added here.