### PR TITLE
Add `.editorconfig` & apply style rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,368 @@
+root = true
+
+# All files
+[*]
+indent_style             = space
+trim_trailing_whitespace = true
+
+# New line preferences
+end_of_line          = crlf
+insert_final_newline = true
+
+# Xml project files
+[*.{csproj,proj}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets}]
+indent_size = 2
+
+# Other markup files
+[*.{json,xml,yml}]
+indent_size = 2
+
+# Markdown files
+[*.md]
+indent_size              = 2
+trim_trailing_whitespace = false
+
+# C# files
+[*.cs]
+indent_size = 4
+
+
+#### C# Style Rules ####
+[*.cs]
+
+file_header_template = unset
+
+# Uncategorized rules (diagnostics without a property equivalent)
+
+dotnet_diagnostic.IDE0001.severity = suggestion # Simplify name
+dotnet_diagnostic.IDE0002.severity = suggestion # Simplify member access
+dotnet_diagnostic.IDE0004.severity = warning    # Remove unnecessary cast
+dotnet_diagnostic.IDE0005.severity = warning    # Remove unnecessary import
+dotnet_diagnostic.IDE0035.severity = suggestion # Remove unreachable code
+dotnet_diagnostic.IDE0050.severity = warning    # Convert anonymous type to tuple
+dotnet_diagnostic.IDE0051.severity = suggestion # Remove unused private member
+dotnet_diagnostic.IDE0052.severity = suggestion # Remove unread private member
+dotnet_diagnostic.IDE0064.severity = suggestion # Make struct fields writable
+dotnet_diagnostic.IDE0080.severity = warning    # Remove unnecessary suppression operator
+dotnet_diagnostic.IDE0082.severity = warning    # Convert `typeof` to `nameof`
+dotnet_diagnostic.IDE0100.severity = warning    # Remove unnecessary equality operator
+dotnet_diagnostic.IDE0110.severity = suggestion # Remove unnecessary discard
+dotnet_diagnostic.IDE0120.severity = warning    # Simplify LINQ expression
+dotnet_diagnostic.IDE0280.severity = warning    # Use `nameof`
+
+
+#### .NET Coding Conventions ####
+
+# Organize usings
+dotnet_separate_import_directive_groups = true
+dotnet_sort_system_directives_first     = true
+
+# this. and Me. preferences
+dotnet_style_qualification_for_event    = false:warning
+dotnet_style_qualification_for_field    = false:warning
+dotnet_style_qualification_for_method   = false:warning
+dotnet_style_qualification_for_property = false:warning
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:warning
+dotnet_style_predefined_type_for_member_access             = true:warning
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_other_binary_operators      = always_for_clarity:warning
+dotnet_style_parentheses_in_other_operators             = never_if_unnecessary:warning
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:warning
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:warning
+
+# Expression-level preferences
+dotnet_style_coalesce_expression                                 = true:suggestion
+dotnet_style_collection_initializer                              = true:warning
+dotnet_style_explicit_tuple_names                                = true:warning
+dotnet_style_null_propagation                                    = true:suggestion
+dotnet_style_object_initializer                                  = true:warning
+dotnet_style_operator_placement_when_wrapping                    = beginning_of_line
+dotnet_style_prefer_auto_properties                              = true:warning
+dotnet_style_prefer_collection_expression                        = true:suggestion
+dotnet_style_prefer_compound_assignment                          = true:warning
+dotnet_style_prefer_conditional_expression_over_assignment       = true:silent
+dotnet_style_prefer_conditional_expression_over_return           = false:silent
+dotnet_style_prefer_foreach_explicit_cast_in_source              = when_strongly_typed
+dotnet_style_prefer_inferred_anonymous_type_member_names         = false:suggestion
+dotnet_style_prefer_inferred_tuple_names                         = false:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
+dotnet_style_prefer_simplified_boolean_expressions               = true:suggestion
+dotnet_style_prefer_simplified_interpolation                     = true:suggestion
+csharp_style_throw_expression                                    = false:warning
+
+# Field preferences
+dotnet_style_readonly_field = true:warning
+
+# Parameter preferences
+dotnet_code_quality_unused_parameters = all:suggestion
+
+# Suppression preferences
+dotnet_remove_unnecessary_suppression_exclusions = suggestion
+
+# New line preferences
+dotnet_style_allow_multiple_blank_lines_experimental              = false:warning
+dotnet_style_allow_statement_immediately_after_block_experimental = false:warning
+
+
+#### C# Coding Conventions ####
+
+# readonly preferences
+csharp_style_prefer_readonly_struct        = true:warning
+csharp_style_prefer_readonly_struct_member = true:warning
+
+# var preferences
+csharp_style_var_elsewhere             = false:suggestion
+csharp_style_var_for_built_in_types    = false:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_accessors       = when_on_single_line:suggestion
+csharp_style_expression_bodied_constructors    = false:warning
+csharp_style_expression_bodied_indexers        = when_on_single_line:suggestion
+csharp_style_expression_bodied_lambdas         = when_on_single_line:suggestion
+csharp_style_expression_bodied_local_functions = false:warning
+csharp_style_expression_bodied_methods         = false:warning
+csharp_style_expression_bodied_operators       = false:warning
+csharp_style_expression_bodied_properties      = when_on_single_line:suggestion
+
+# Pattern matching preferences
+csharp_style_pattern_matching_over_as_with_null_check = true:warning
+csharp_style_pattern_matching_over_is_with_cast_check = true:warning
+csharp_style_prefer_not_pattern                       = true:warning
+csharp_style_prefer_extended_property_pattern         = true:warning
+csharp_style_prefer_pattern_matching                  = true:suggestion
+csharp_style_prefer_switch_expression                 = true:suggestion
+
+# Null-checking preferences
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Modifier preferences
+csharp_prefer_static_local_function = true:warning
+csharp_preferred_modifier_order     = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:silent
+
+# Code-block preferences
+csharp_prefer_braces                        = true:warning
+csharp_prefer_simple_using_statement        = true:warning
+csharp_style_prefer_method_group_conversion = true:suggestion
+csharp_style_prefer_top_level_statements    = true:suggestion
+
+# Expression-level preferences
+csharp_prefer_simple_default_expression                     = true:warning
+csharp_style_deconstructed_variable_declaration             = true:warning
+csharp_style_implicit_object_creation_when_type_is_apparent = true:warning
+csharp_style_inlined_variable_declaration                   = true:warning
+csharp_style_pattern_local_over_anonymous_function          = true:warning
+csharp_style_prefer_index_operator                          = true:warning
+csharp_style_prefer_local_over_anonymous_function           = true:warning
+csharp_style_prefer_null_check_over_type_check              = true:warning
+csharp_style_prefer_range_operator                          = true:warning
+csharp_style_prefer_tuple_swap                              = true:warning
+csharp_style_prefer_utf8_string_literals                    = true:suggestion
+csharp_style_unused_value_assignment_preference             = discard_variable:none
+csharp_style_unused_value_expression_statement_preference   = discard_variable:none
+
+# 'using' directive preferences
+csharp_using_directive_placement = outside_namespace:warning
+
+
+#### C# Formatting Rules ####
+
+# New line preferences
+csharp_new_line_before_catch                                                      = true
+csharp_new_line_before_else                                                       = true
+csharp_new_line_before_finally                                                    = true
+csharp_new_line_before_members_in_anonymous_types                                 = true
+csharp_new_line_before_members_in_object_initializers                             = true
+csharp_new_line_before_open_brace                                                 = all
+csharp_new_line_between_query_expression_clauses                                  = true
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = false:warning
+csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental  = false:warning
+csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = false:warning
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental            = false:warning
+csharp_style_allow_embedded_statements_on_same_line_experimental                  = false:warning
+
+# Indentation preferences
+csharp_indent_block_contents           = true
+csharp_indent_braces                   = false
+csharp_indent_case_contents            = true
+csharp_indent_case_contents_when_block = false
+csharp_indent_labels                   = one_less_than_current
+csharp_indent_switch_labels            = true
+
+# Space preferences
+csharp_space_after_cast                                                  = false
+csharp_space_after_colon_in_inheritance_clause                           = true
+csharp_space_after_comma                                                 = true
+csharp_space_after_dot                                                   = false
+csharp_space_after_keywords_in_control_flow_statements                   = true
+csharp_space_after_semicolon_in_for_statement                            = true
+csharp_space_around_binary_operators                                     = before_and_after
+csharp_space_around_declaration_statements                               = false
+csharp_space_before_colon_in_inheritance_clause                          = true
+csharp_space_before_comma                                                = false
+csharp_space_before_dot                                                  = false
+csharp_space_before_open_square_brackets                                 = false
+csharp_space_before_semicolon_in_for_statement                           = false
+csharp_space_between_empty_square_brackets                               = false
+csharp_space_between_method_call_empty_parameter_list_parentheses        = false
+csharp_space_between_method_call_name_and_opening_parenthesis            = false
+csharp_space_between_method_call_parameter_list_parentheses              = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis        = false
+csharp_space_between_method_declaration_parameter_list_parentheses       = false
+csharp_space_between_parentheses                                         = false
+csharp_space_between_square_brackets                                     = false
+
+# Wrapping preferences
+csharp_preserve_single_line_blocks     = true
+csharp_preserve_single_line_statements = true
+
+# Namespace preferences
+csharp_style_namespace_declarations = file_scoped:warning
+dotnet_style_namespace_match_folder = false
+
+# Constructor preferences
+csharp_style_prefer_primary_constructors = false:none
+
+
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.symbols  = types_and_namespaces
+dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.interfaces_should_be_ipascalcase.severity = suggestion
+dotnet_naming_rule.interfaces_should_be_ipascalcase.symbols  = interfaces
+dotnet_naming_rule.interfaces_should_be_ipascalcase.style    = ipascalcase
+
+dotnet_naming_rule.non_field_members_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascalcase.symbols  = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.constant_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascalcase.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.public_static_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.public_static_fields_should_be_pascalcase.symbols  = public_static_fields
+dotnet_naming_rule.public_static_fields_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.public_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.public_fields_should_be_pascalcase.symbols  = public_fields
+dotnet_naming_rule.public_fields_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.private_fields_should_be__camelcase.severity = suggestion
+dotnet_naming_rule.private_fields_should_be__camelcase.symbols  = private_fields
+dotnet_naming_rule.private_fields_should_be__camelcase.style    = _camelcase
+
+dotnet_naming_rule.type_parameters_should_be_tpascalcase.severity = warning
+dotnet_naming_rule.type_parameters_should_be_tpascalcase.symbols  = type_parameters
+dotnet_naming_rule.type_parameters_should_be_tpascalcase.style    = tpascalcase
+
+dotnet_naming_rule.parameters_should_be_camelcase.severity = suggestion
+dotnet_naming_rule.parameters_should_be_camelcase.symbols  = parameters
+dotnet_naming_rule.parameters_should_be_camelcase.style    = camelcase
+
+dotnet_naming_rule.local_constants_should_be_pascalcase.severity = warning
+dotnet_naming_rule.local_constants_should_be_pascalcase.symbols  = local_constants
+dotnet_naming_rule.local_constants_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.local_variables_should_be_camelcase.severity = warning
+dotnet_naming_rule.local_variables_should_be_camelcase.symbols  = local_variables
+dotnet_naming_rule.local_variables_should_be_camelcase.style    = camelcase
+
+dotnet_naming_rule.local_functions_should_be_camelcase.severity = warning
+dotnet_naming_rule.local_functions_should_be_camelcase.symbols  = local_functions
+dotnet_naming_rule.local_functions_should_be_camelcase.style    = camelcase
+
+# Symbol specifications
+
+dotnet_naming_symbols.types_and_namespaces.applicable_kinds           = namespace, class, struct, interface, enum
+dotnet_naming_symbols.types_and_namespaces.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types_and_namespaces.required_modifiers         =
+
+dotnet_naming_symbols.interfaces.applicable_kinds           = interface
+dotnet_naming_symbols.interfaces.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interfaces.required_modifiers         =
+
+dotnet_naming_symbols.non_field_members.applicable_kinds           = property, event, delegate, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers         =
+
+dotnet_naming_symbols.constant_fields.applicable_kinds           = field
+dotnet_naming_symbols.constant_fields.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.constant_fields.required_modifiers         = const
+
+dotnet_naming_symbols.public_static_fields.applicable_kinds           = field
+dotnet_naming_symbols.public_static_fields.applicable_accessibilities = public, internal
+dotnet_naming_symbols.public_static_fields.required_modifiers         = static
+
+dotnet_naming_symbols.public_fields.applicable_kinds           = field
+dotnet_naming_symbols.public_fields.applicable_accessibilities = public, internal
+dotnet_naming_symbols.public_fields.required_modifiers         =
+
+dotnet_naming_symbols.private_fields.applicable_kinds           = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private, protected, protected_internal, private_protected
+dotnet_naming_symbols.private_fields.required_modifiers         =
+
+dotnet_naming_symbols.type_parameters.applicable_kinds           = type_parameter
+dotnet_naming_symbols.type_parameters.applicable_accessibilities = *
+dotnet_naming_symbols.type_parameters.required_modifiers         =
+
+dotnet_naming_symbols.parameters.applicable_kinds           = parameter
+dotnet_naming_symbols.parameters.applicable_accessibilities = *
+dotnet_naming_symbols.parameters.required_modifiers         =
+
+dotnet_naming_symbols.local_constants.applicable_kinds           = local
+dotnet_naming_symbols.local_constants.applicable_accessibilities = local
+dotnet_naming_symbols.local_constants.required_modifiers         = const
+
+dotnet_naming_symbols.local_variables.applicable_kinds           = local
+dotnet_naming_symbols.local_variables.applicable_accessibilities = local
+dotnet_naming_symbols.local_variables.required_modifiers         =
+
+dotnet_naming_symbols.local_functions.applicable_kinds           = local_function
+dotnet_naming_symbols.local_functions.applicable_accessibilities = local
+dotnet_naming_symbols.local_functions.required_modifiers         =
+
+# Naming styles
+
+dotnet_naming_style.pascalcase.required_prefix =
+dotnet_naming_style.pascalcase.required_suffix =
+dotnet_naming_style.pascalcase.word_separator  =
+dotnet_naming_style.pascalcase.capitalization  = pascal_case
+
+dotnet_naming_style.ipascalcase.required_prefix = I
+dotnet_naming_style.ipascalcase.required_suffix =
+dotnet_naming_style.ipascalcase.word_separator  =
+dotnet_naming_style.ipascalcase.capitalization  = pascal_case
+
+dotnet_naming_style.tpascalcase.required_prefix = T
+dotnet_naming_style.tpascalcase.required_suffix =
+dotnet_naming_style.tpascalcase.word_separator  =
+dotnet_naming_style.tpascalcase.capitalization  = pascal_case
+
+dotnet_naming_style.camelcase.required_prefix =
+dotnet_naming_style.camelcase.required_suffix =
+dotnet_naming_style.camelcase.word_separator  =
+dotnet_naming_style.camelcase.capitalization  = camel_case
+
+dotnet_naming_style._camelcase.required_prefix = _
+dotnet_naming_style._camelcase.required_suffix =
+dotnet_naming_style._camelcase.word_separator  =
+dotnet_naming_style._camelcase.capitalization  = camel_case
+
+
+#### Suppressions ####

--- a/props/LiveSplit.Title.props
+++ b/props/LiveSplit.Title.props
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <LangVersion>12</LangVersion>
 
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <Nullable>disable</Nullable>
   </PropertyGroup>
 

--- a/props/LiveSplit.Title.props
+++ b/props/LiveSplit.Title.props
@@ -2,6 +2,8 @@
 
   <!-- Project properties. -->
   <PropertyGroup>
+    <LangVersion>12</LangVersion>
+
     <Nullable>disable</Nullable>
   </PropertyGroup>
 

--- a/src/LiveSplit.Title/LiveSplit.Title.csproj
+++ b/src/LiveSplit.Title/LiveSplit.Title.csproj
@@ -14,4 +14,8 @@
     <ProjectReference Include="$(LsSrcPath)\UpdateManager\UpdateManager.csproj" Private="false" ExcludeAssets="runtime" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="PolySharp" Version="1.14.1" PrivateAssets="all" />
+  </ItemGroup>
+
 </Project>

--- a/src/LiveSplit.Title/UI/Components/AlignmentType.cs
+++ b/src/LiveSplit.Title/UI/Components/AlignmentType.cs
@@ -1,9 +1,8 @@
-﻿namespace LiveSplit.UI.Components
+﻿namespace LiveSplit.UI.Components;
+
+public enum AlignmentType
 {
-    public enum AlignmentType
-    {
-        Auto = 0,
-        Left = 1,
-        Center = 2
-    }
+    Auto = 0,
+    Left = 1,
+    Center = 2
 }

--- a/src/LiveSplit.Title/UI/Components/Title.cs
+++ b/src/LiveSplit.Title/UI/Components/Title.cs
@@ -98,8 +98,7 @@ public class Title : IComponent
 
         DrawAttemptCount(g, state, width, height);
 
-        float startPadding, titleEndPadding, categoryEndPadding;
-        CalculatePadding(height, mode, showGameIcon, out startPadding, out titleEndPadding, out categoryEndPadding);
+        CalculatePadding(height, mode, showGameIcon, out float startPadding, out float titleEndPadding, out float categoryEndPadding);
 
         DrawGameName(g, state, width, height, showGameIcon, startPadding, titleEndPadding);
         DrawCategoryName(g, state, width, height, showGameIcon, startPadding, categoryEndPadding);

--- a/src/LiveSplit.Title/UI/Components/Title.cs
+++ b/src/LiveSplit.Title/UI/Components/Title.cs
@@ -425,5 +425,8 @@ public class Title : IComponent
     {
     }
 
-    public int GetSettingsHashCode() => Settings.GetSettingsHashCode();
+    public int GetSettingsHashCode()
+    {
+        return Settings.GetSettingsHashCode();
+    }
 }

--- a/src/LiveSplit.Title/UI/Components/Title.cs
+++ b/src/LiveSplit.Title/UI/Components/Title.cs
@@ -1,5 +1,4 @@
-﻿using LiveSplit.Model;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Drawing2D;
@@ -8,422 +7,423 @@ using System.Linq;
 using System.Windows.Forms;
 using System.Xml;
 
-namespace LiveSplit.UI.Components
+using LiveSplit.Model;
+
+namespace LiveSplit.UI.Components;
+
+public class Title : IComponent
 {
-    public class Title : IComponent
+    public TitleSettings Settings { get; set; }
+    public float VerticalHeight { get; set; }
+    public GraphicsCache Cache { get; set; }
+    protected int FrameCount { get; set; }
+    protected Image OldImage { get; set; }
+    protected int FinishedRunsInHistory { get; set; }
+
+    public float MinimumWidth => GameNameLabel.X + AttemptCountLabel.ActualWidth + 5;
+
+    public float HorizontalWidth
     {
-        public TitleSettings Settings { get; set; }
-        public float VerticalHeight { get; set; }
-        public GraphicsCache Cache { get; set; }
-        protected int FrameCount { get; set; }
-        protected Image OldImage { get; set; }
-        protected int FinishedRunsInHistory { get; set; }
-
-        public float MinimumWidth => GameNameLabel.X + AttemptCountLabel.ActualWidth + 5;
-
-        public float HorizontalWidth
+        get
         {
-            get
+            if (!Settings.ShowCount)
             {
-                if (!Settings.ShowCount)
-                {
-                    return Math.Max(GameNameLabel.ActualWidth, CategoryNameLabel.ActualWidth) + GameNameLabel.X + 5;
-                }
-
-                // If the category + attempt is longer than the name, just return category + attempts
-                if (CategoryNameLabel.ActualWidth + AttemptCountLabel.ActualWidth > GameNameLabel.ActualWidth)
-                {
-                    return CategoryNameLabel.ActualWidth + AttemptCountLabel.ActualWidth + CategoryNameLabel.X + 5;
-                }
-
-                // The game name is longer than the category+attempts, so center the category, then add the attempts and compare with the game name.
-                float centeredCategoryWidth = GameNameLabel.ActualWidth / 2 + CategoryNameLabel.ActualWidth / 2 + AttemptCountLabel.ActualWidth;
-                if (centeredCategoryWidth > GameNameLabel.ActualWidth)
-                {
-                    return centeredCategoryWidth + CategoryNameLabel.X + 5;
-                }
-                else
-                {
-                    return GameNameLabel.ActualWidth + GameNameLabel.X + 5;
-                }
-            }
-        }
-
-
-        public IDictionary<string, Action> ContextMenuControls => null;
-
-        public float PaddingTop => 0f;
-        public float PaddingLeft => 7f;
-        public float PaddingBottom => 0f;
-        public float PaddingRight => 7f;
-
-        protected SimpleLabel GameNameLabel = new SimpleLabel();
-        protected SimpleLabel CategoryNameLabel = new SimpleLabel();
-        protected SimpleLabel AttemptCountLabel = new SimpleLabel();
-
-        protected Font TitleFont { get; set; }
-
-        public float MinimumHeight { get; set; }
-
-        public Title()
-        {
-            VerticalHeight = 10;
-            Settings = new TitleSettings();
-            Cache = new GraphicsCache();
-            GameNameLabel = new SimpleLabel();
-            CategoryNameLabel = new SimpleLabel();
-            AttemptCountLabel = new SimpleLabel();
-        }
-
-        private void DrawGeneral(Graphics g, LiveSplitState state, float width, float height, LayoutMode mode)
-        {
-            DrawBackground(g, width, height);
-
-            if (Settings.OverrideTitleFont)
-                TitleFont = Settings.TitleFont;
-            else
-                TitleFont = state.LayoutSettings.TextFont;
-
-            MinimumHeight = g.MeasureString("A", TitleFont).Height * 1.7f;
-            VerticalHeight = g.MeasureString("A", TitleFont).Height * 1.7f;
-            var showGameIcon = state.Run.GameIcon != null && Settings.DisplayGameIcon;
-            if (showGameIcon)
-            {
-                DrawGameIcon(g, state, height);
+                return Math.Max(GameNameLabel.ActualWidth, CategoryNameLabel.ActualWidth) + GameNameLabel.X + 5;
             }
 
-            DrawAttemptCount(g, state, width, height);
-
-            float startPadding, titleEndPadding, categoryEndPadding;
-            CalculatePadding(height, mode, showGameIcon, out startPadding, out titleEndPadding, out categoryEndPadding);
-
-            DrawGameName(g, state, width, height, showGameIcon, startPadding, titleEndPadding);
-            DrawCategoryName(g, state, width, height, showGameIcon, startPadding, categoryEndPadding);
-        }
-
-        private void DrawBackground(Graphics g, float width, float height)
-        {
-            if (Settings.BackgroundColor.A > 0
-                || Settings.BackgroundGradient != GradientType.Plain
-                && Settings.BackgroundColor2.A > 0)
+            // If the category + attempt is longer than the name, just return category + attempts
+            if (CategoryNameLabel.ActualWidth + AttemptCountLabel.ActualWidth > GameNameLabel.ActualWidth)
             {
-                var gradientBrush = new LinearGradientBrush(
-                            new PointF(0, 0),
-                            Settings.BackgroundGradient == GradientType.Horizontal
-                            ? new PointF(width, 0)
-                            : new PointF(0, height),
-                            Settings.BackgroundColor,
-                            Settings.BackgroundGradient == GradientType.Plain
-                            ? Settings.BackgroundColor
-                            : Settings.BackgroundColor2);
-                g.FillRectangle(gradientBrush, 0, 0, width, height);
+                return CategoryNameLabel.ActualWidth + AttemptCountLabel.ActualWidth + CategoryNameLabel.X + 5;
             }
-        }
 
-        private void CalculatePadding(float height, LayoutMode mode, bool showGameIcon, out float startPadding, out float titleEndPadding, out float categoryEndPadding)
-        {
-            startPadding = 5;
-            titleEndPadding = 5;
-            categoryEndPadding = 5;
-            if (showGameIcon)
+            // The game name is longer than the category+attempts, so center the category, then add the attempts and compare with the game name.
+            float centeredCategoryWidth = GameNameLabel.ActualWidth / 2 + CategoryNameLabel.ActualWidth / 2 + AttemptCountLabel.ActualWidth;
+            if (centeredCategoryWidth > GameNameLabel.ActualWidth)
             {
-                startPadding += height + 3;
-            }
-            if (mode == LayoutMode.Vertical && Settings.ShowCount)
-            {
-                if (string.IsNullOrEmpty(CategoryNameLabel.Text))
-                {
-                    titleEndPadding += AttemptCountLabel.ActualWidth;
-                }
-                else
-                {
-                    categoryEndPadding += AttemptCountLabel.ActualWidth;
-                }
-            }
-        }
-
-        private void DrawCategoryName(Graphics g, LiveSplitState state, float width, float height, bool showGameIcon, float startPadding, float categoryEndPadding)
-        {
-            if (Settings.TextAlignment == AlignmentType.Center || (Settings.TextAlignment == AlignmentType.Auto && !showGameIcon))
-            {
-                CategoryNameLabel.CalculateAlternateText(g, width - startPadding - categoryEndPadding);
-                float stringWidth = CategoryNameLabel.ActualWidth;
-                PositionAndWidth positionAndWidth = calculateCenteredPositionAndWidth(width, stringWidth, startPadding, categoryEndPadding);
-                CategoryNameLabel.X = positionAndWidth.position;
-                CategoryNameLabel.Width = positionAndWidth.width;
+                return centeredCategoryWidth + CategoryNameLabel.X + 5;
             }
             else
             {
-                CategoryNameLabel.X = startPadding;
-                CategoryNameLabel.Width = width - startPadding - categoryEndPadding;
-            }
-            CategoryNameLabel.Y = 0;
-            CategoryNameLabel.HorizontalAlignment = StringAlignment.Near;
-            CategoryNameLabel.VerticalAlignment = string.IsNullOrEmpty(GameNameLabel.Text) ? StringAlignment.Center : StringAlignment.Far;
-            CategoryNameLabel.Font = TitleFont;
-            CategoryNameLabel.Brush = new SolidBrush(Settings.OverrideTitleColor ? Settings.TitleColor : state.LayoutSettings.TextColor);
-            CategoryNameLabel.HasShadow = state.LayoutSettings.DropShadows;
-            CategoryNameLabel.ShadowColor = state.LayoutSettings.ShadowsColor;
-            CategoryNameLabel.OutlineColor = state.LayoutSettings.TextOutlineColor;
-            CategoryNameLabel.Height = height;
-            CategoryNameLabel.Draw(g);
-        }
-
-        private void DrawAttemptCount(Graphics g, LiveSplitState state, float width, float height)
-        {
-            if (Settings.ShowCount)
-            {
-                AttemptCountLabel.HorizontalAlignment = StringAlignment.Far;
-                AttemptCountLabel.VerticalAlignment = StringAlignment.Far;
-                AttemptCountLabel.X = 0;
-                AttemptCountLabel.Y = height - 40;
-                AttemptCountLabel.Width = width - 5;
-                AttemptCountLabel.Height = 40;
-                AttemptCountLabel.Font = TitleFont;
-                AttemptCountLabel.Brush = new SolidBrush(Settings.OverrideTitleColor ? Settings.TitleColor : state.LayoutSettings.TextColor);
-                AttemptCountLabel.HasShadow = state.LayoutSettings.DropShadows;
-                AttemptCountLabel.ShadowColor = state.LayoutSettings.ShadowsColor;
-                AttemptCountLabel.OutlineColor = state.LayoutSettings.TextOutlineColor;
-                AttemptCountLabel.Draw(g);
+                return GameNameLabel.ActualWidth + GameNameLabel.X + 5;
             }
         }
-
-        private void DrawGameName(Graphics g, LiveSplitState state, float width, float height, bool showGameIcon, float startPadding, float titleEndPadding)
-        {
-            if (Settings.TextAlignment == AlignmentType.Center || (Settings.TextAlignment == AlignmentType.Auto && !showGameIcon))
-            {
-                GameNameLabel.CalculateAlternateText(g, width - startPadding - titleEndPadding);
-                float stringWidth = GameNameLabel.ActualWidth;
-                PositionAndWidth positionAndWidth = calculateCenteredPositionAndWidth(width, stringWidth, startPadding, titleEndPadding);
-                GameNameLabel.X = positionAndWidth.position;
-                GameNameLabel.Width = positionAndWidth.width;
-            }
-            else
-            {
-                GameNameLabel.X = startPadding;
-                GameNameLabel.Width = width - startPadding - titleEndPadding;
-            }
-
-            GameNameLabel.HorizontalAlignment = StringAlignment.Near;
-            GameNameLabel.VerticalAlignment = string.IsNullOrEmpty(CategoryNameLabel.Text) ? StringAlignment.Center : StringAlignment.Near;
-            GameNameLabel.Y = 0;
-            GameNameLabel.Height = height;
-            GameNameLabel.Font = TitleFont;
-            GameNameLabel.Brush = new SolidBrush(Settings.OverrideTitleColor ? Settings.TitleColor : state.LayoutSettings.TextColor);
-            GameNameLabel.HasShadow = state.LayoutSettings.DropShadows;
-            GameNameLabel.ShadowColor = state.LayoutSettings.ShadowsColor;
-            GameNameLabel.OutlineColor = state.LayoutSettings.TextOutlineColor;
-            GameNameLabel.Draw(g);
-        }
-
-        private void DrawGameIcon(Graphics g, LiveSplitState state, float height)
-        {
-            var icon = state.Run.GameIcon;
-
-            if (OldImage != icon)
-            {
-                ImageAnimator.Animate(icon, (s, o) => { });
-                OldImage = icon;
-            }
-
-            var aspectRatio = (float)icon.Width / icon.Height;
-            var drawWidth = height - 4;
-            var drawHeight = height - 4;
-            if (icon.Width > icon.Height)
-            {
-                var ratio = icon.Height / (float)icon.Width;
-                drawHeight *= ratio;
-            }
-            else
-            {
-                var ratio = icon.Width / (float)icon.Height;
-                drawWidth *= ratio;
-            }
-
-            ImageAnimator.UpdateFrames(icon);
-
-            g.DrawImage(
-                icon,
-                7 + (height - 4 - drawWidth) / 2,
-                2 + (height - 4 - drawHeight) / 2,
-                drawWidth,
-                drawHeight);
-        }
-
-        /*
-         * Returns coordinate and width of the string element so that the text is centered in the total width
-         * while not overlapping into the start or ending padding.
-         */
-        private PositionAndWidth calculateCenteredPositionAndWidth(float totalWidth, float stringWidth, float startPadding, float endPadding)
-        {
-            float position, width;
-            if (startPadding + stringWidth + endPadding > totalWidth)
-            {
-                // We cant fit no matter what we do, so start the string after the start padding 
-                position = startPadding;
-            }
-            else
-            {
-                // Try to center, but push the string left or right if it overlaps the padding
-                position = (totalWidth - stringWidth) / 2;
-                position = Math.Max(position, startPadding);
-                if (position + stringWidth > totalWidth - endPadding)
-                {
-                    position = totalWidth - endPadding - stringWidth;
-                }
-            }
-            width = totalWidth - endPadding - position;
-            return new PositionAndWidth(position, width);
-        }
-
-        private class PositionAndWidth
-        {
-            public float position { get; set; }
-            public float width { get; set; }
-            public PositionAndWidth(float position, float width)
-            {
-                this.position = position;
-                this.width = width;
-            }
-        }
-
-        public void DrawHorizontal(Graphics g, LiveSplitState state, float height, Region clipRegion)
-        {
-            DrawGeneral(g, state, HorizontalWidth, height, LayoutMode.Horizontal);
-        }
-
-        public void DrawVertical(Graphics g, LiveSplitState state, float width, Region clipRegion)
-        {
-            DrawGeneral(g, state, width, VerticalHeight, LayoutMode.Vertical);
-        }
-
-        public string ComponentName => "Title";
-
-        public Control GetSettingsControl(LayoutMode mode)
-        {
-            return Settings;
-        }
-
-        public XmlNode GetSettings(XmlDocument document)
-        {
-            return Settings.GetSettings(document);
-        }
-
-        public void SetSettings(XmlNode settings)
-        {
-            Settings.SetSettings(settings);
-        }
-
-        private IEnumerable<string> getCategoryNameAbbreviations(string categoryName)
-        {
-            var indexStart = categoryName.IndexOf('(');
-            var indexEnd = categoryName.IndexOf(')', indexStart + 1);
-            var afterParentheses = "";
-            if (indexStart >= 0 && indexEnd >= 0)
-            {
-                var inside = categoryName.Substring(indexStart + 1, indexEnd - indexStart - 1);
-                afterParentheses = categoryName.Substring(indexEnd + 1).Trim();
-                categoryName = categoryName.Substring(0, indexStart).Trim();
-                var splits = inside.Split(',');
-
-                for (var i = splits.Length - 1; i > 0; --i)
-                {
-                    yield return $"{ categoryName } ({ string.Join(",", splits.Take(i)) }) { afterParentheses }".Trim();
-                }
-            }
-            yield return $"{ categoryName } { afterParentheses }".Trim();
-        }
-
-        public void Update(IInvalidator invalidator, LiveSplitState state, float width, float height, LayoutMode mode)
-        {
-            var extendedCategoryName = state.Run.GetExtendedCategoryName(Settings.ShowRegion, Settings.ShowPlatform, Settings.ShowVariables);
-
-            Cache.Restart();
-            Cache["SingleLine"] = Settings.SingleLine;
-            Cache["GameName"] = state.Run.GameName;
-            Cache["CategoryName"] = extendedCategoryName;
-            Cache["LayoutMode"] = mode;
-            Cache["ShowGameName"] = Settings.ShowGameName;
-            Cache["ShowCategoryName"] = Settings.ShowCategoryName;
-            if (Cache.HasChanged)
-            {
-                if (Settings.SingleLine && Settings.ShowGameName && Settings.ShowCategoryName)
-                {
-                    var text = string.Format("{0} - {1}", state.Run.GameName, extendedCategoryName);
-                    var gameAbbreviations = state.Run.GameName.GetAbbreviations();
-                    var shortestGameName = gameAbbreviations.Last();
-                    var categoryAbbreviations = getCategoryNameAbbreviations(extendedCategoryName);
-                    var combinedAbbreviations1 = gameAbbreviations.Select(x => string.Format("{0} - {1}", x, extendedCategoryName));
-                    var combinedAbbreviations2 = categoryAbbreviations.Select(x => string.Format("{0} - {1}", shortestGameName, x));
-                    var abbreviations = combinedAbbreviations1.Concat(combinedAbbreviations2).ToList();
-                    GameNameLabel.Text = text;
-                    GameNameLabel.AlternateText = mode == LayoutMode.Vertical ? abbreviations : new List<string>();
-                    CategoryNameLabel.Text = "";
-                }
-                else
-                {
-                    if (Settings.ShowGameName)
-                    {
-                        GameNameLabel.Text = state.Run.GameName;
-                        GameNameLabel.AlternateText = mode == LayoutMode.Vertical ? state.Run.GameName.GetAbbreviations().ToList() : new List<string>();
-                    }
-                    else
-                    {
-                        GameNameLabel.Text = "";
-                        GameNameLabel.AlternateText = new List<string>();
-                    }
-                    if (Settings.ShowCategoryName)
-                    {
-                        CategoryNameLabel.Text = extendedCategoryName;
-                        CategoryNameLabel.AlternateText = mode == LayoutMode.Vertical ? getCategoryNameAbbreviations(extendedCategoryName).ToList() : new List<string>();
-                    }
-                    else
-                    {
-                        CategoryNameLabel.Text = "";
-                        CategoryNameLabel.AlternateText = new List<string>();
-                    }
-                }
-            }
-
-            Cache.Restart();
-            Cache["AttemptHistoryCount"] = state.Run.AttemptHistory.Count;
-            Cache["Run"] = state.Run;
-            if (Cache.HasChanged)
-                FinishedRunsInHistory = state.Run.AttemptHistory.Where(x => x.Time.RealTime != null).Count();
-            var totalFinishedRunsCount = FinishedRunsInHistory + (state.CurrentPhase == TimerPhase.Ended ? 1 : 0);
-
-            if (Settings.ShowAttemptCount && Settings.ShowFinishedRunsCount)
-                AttemptCountLabel.Text = string.Format("{0}/{1}", totalFinishedRunsCount, state.Run.AttemptCount);
-            else if (Settings.ShowAttemptCount)
-                AttemptCountLabel.Text = state.Run.AttemptCount.ToString();
-            else if (Settings.ShowFinishedRunsCount)
-                AttemptCountLabel.Text = totalFinishedRunsCount.ToString();
-
-
-            Cache.Restart();
-            Cache["GameIcon"] = state.Run.GameIcon;
-            if (Cache.HasChanged)
-            {
-                if (state.Run.GameIcon == null)
-                    FrameCount = 0;
-                else
-                    FrameCount = state.Run.GameIcon.GetFrameCount(new FrameDimension(state.Run.GameIcon.FrameDimensionsList[0]));
-            }
-            Cache["GameNameLabel"] = GameNameLabel.Text;
-            Cache["CategoryNameLabel"] = CategoryNameLabel.Text;
-            Cache["AttemptCountLabel"] = AttemptCountLabel.Text;
-            Cache["TextAlignment"] = Settings.TextAlignment;
-
-            if (invalidator != null && (Cache.HasChanged || FrameCount > 1))
-            {
-                invalidator.Invalidate(0, 0, width, height);
-            }
-        }
-
-        public void Dispose()
-        {
-        }
-
-        public int GetSettingsHashCode() => Settings.GetSettingsHashCode();
     }
+
+
+    public IDictionary<string, Action> ContextMenuControls => null;
+
+    public float PaddingTop => 0f;
+    public float PaddingLeft => 7f;
+    public float PaddingBottom => 0f;
+    public float PaddingRight => 7f;
+
+    protected SimpleLabel GameNameLabel = new SimpleLabel();
+    protected SimpleLabel CategoryNameLabel = new SimpleLabel();
+    protected SimpleLabel AttemptCountLabel = new SimpleLabel();
+
+    protected Font TitleFont { get; set; }
+
+    public float MinimumHeight { get; set; }
+
+    public Title()
+    {
+        VerticalHeight = 10;
+        Settings = new TitleSettings();
+        Cache = new GraphicsCache();
+        GameNameLabel = new SimpleLabel();
+        CategoryNameLabel = new SimpleLabel();
+        AttemptCountLabel = new SimpleLabel();
+    }
+
+    private void DrawGeneral(Graphics g, LiveSplitState state, float width, float height, LayoutMode mode)
+    {
+        DrawBackground(g, width, height);
+
+        if (Settings.OverrideTitleFont)
+            TitleFont = Settings.TitleFont;
+        else
+            TitleFont = state.LayoutSettings.TextFont;
+
+        MinimumHeight = g.MeasureString("A", TitleFont).Height * 1.7f;
+        VerticalHeight = g.MeasureString("A", TitleFont).Height * 1.7f;
+        var showGameIcon = state.Run.GameIcon != null && Settings.DisplayGameIcon;
+        if (showGameIcon)
+        {
+            DrawGameIcon(g, state, height);
+        }
+
+        DrawAttemptCount(g, state, width, height);
+
+        float startPadding, titleEndPadding, categoryEndPadding;
+        CalculatePadding(height, mode, showGameIcon, out startPadding, out titleEndPadding, out categoryEndPadding);
+
+        DrawGameName(g, state, width, height, showGameIcon, startPadding, titleEndPadding);
+        DrawCategoryName(g, state, width, height, showGameIcon, startPadding, categoryEndPadding);
+    }
+
+    private void DrawBackground(Graphics g, float width, float height)
+    {
+        if (Settings.BackgroundColor.A > 0
+            || Settings.BackgroundGradient != GradientType.Plain
+            && Settings.BackgroundColor2.A > 0)
+        {
+            var gradientBrush = new LinearGradientBrush(
+                        new PointF(0, 0),
+                        Settings.BackgroundGradient == GradientType.Horizontal
+                        ? new PointF(width, 0)
+                        : new PointF(0, height),
+                        Settings.BackgroundColor,
+                        Settings.BackgroundGradient == GradientType.Plain
+                        ? Settings.BackgroundColor
+                        : Settings.BackgroundColor2);
+            g.FillRectangle(gradientBrush, 0, 0, width, height);
+        }
+    }
+
+    private void CalculatePadding(float height, LayoutMode mode, bool showGameIcon, out float startPadding, out float titleEndPadding, out float categoryEndPadding)
+    {
+        startPadding = 5;
+        titleEndPadding = 5;
+        categoryEndPadding = 5;
+        if (showGameIcon)
+        {
+            startPadding += height + 3;
+        }
+        if (mode == LayoutMode.Vertical && Settings.ShowCount)
+        {
+            if (string.IsNullOrEmpty(CategoryNameLabel.Text))
+            {
+                titleEndPadding += AttemptCountLabel.ActualWidth;
+            }
+            else
+            {
+                categoryEndPadding += AttemptCountLabel.ActualWidth;
+            }
+        }
+    }
+
+    private void DrawCategoryName(Graphics g, LiveSplitState state, float width, float height, bool showGameIcon, float startPadding, float categoryEndPadding)
+    {
+        if (Settings.TextAlignment == AlignmentType.Center || (Settings.TextAlignment == AlignmentType.Auto && !showGameIcon))
+        {
+            CategoryNameLabel.CalculateAlternateText(g, width - startPadding - categoryEndPadding);
+            float stringWidth = CategoryNameLabel.ActualWidth;
+            PositionAndWidth positionAndWidth = calculateCenteredPositionAndWidth(width, stringWidth, startPadding, categoryEndPadding);
+            CategoryNameLabel.X = positionAndWidth.position;
+            CategoryNameLabel.Width = positionAndWidth.width;
+        }
+        else
+        {
+            CategoryNameLabel.X = startPadding;
+            CategoryNameLabel.Width = width - startPadding - categoryEndPadding;
+        }
+        CategoryNameLabel.Y = 0;
+        CategoryNameLabel.HorizontalAlignment = StringAlignment.Near;
+        CategoryNameLabel.VerticalAlignment = string.IsNullOrEmpty(GameNameLabel.Text) ? StringAlignment.Center : StringAlignment.Far;
+        CategoryNameLabel.Font = TitleFont;
+        CategoryNameLabel.Brush = new SolidBrush(Settings.OverrideTitleColor ? Settings.TitleColor : state.LayoutSettings.TextColor);
+        CategoryNameLabel.HasShadow = state.LayoutSettings.DropShadows;
+        CategoryNameLabel.ShadowColor = state.LayoutSettings.ShadowsColor;
+        CategoryNameLabel.OutlineColor = state.LayoutSettings.TextOutlineColor;
+        CategoryNameLabel.Height = height;
+        CategoryNameLabel.Draw(g);
+    }
+
+    private void DrawAttemptCount(Graphics g, LiveSplitState state, float width, float height)
+    {
+        if (Settings.ShowCount)
+        {
+            AttemptCountLabel.HorizontalAlignment = StringAlignment.Far;
+            AttemptCountLabel.VerticalAlignment = StringAlignment.Far;
+            AttemptCountLabel.X = 0;
+            AttemptCountLabel.Y = height - 40;
+            AttemptCountLabel.Width = width - 5;
+            AttemptCountLabel.Height = 40;
+            AttemptCountLabel.Font = TitleFont;
+            AttemptCountLabel.Brush = new SolidBrush(Settings.OverrideTitleColor ? Settings.TitleColor : state.LayoutSettings.TextColor);
+            AttemptCountLabel.HasShadow = state.LayoutSettings.DropShadows;
+            AttemptCountLabel.ShadowColor = state.LayoutSettings.ShadowsColor;
+            AttemptCountLabel.OutlineColor = state.LayoutSettings.TextOutlineColor;
+            AttemptCountLabel.Draw(g);
+        }
+    }
+
+    private void DrawGameName(Graphics g, LiveSplitState state, float width, float height, bool showGameIcon, float startPadding, float titleEndPadding)
+    {
+        if (Settings.TextAlignment == AlignmentType.Center || (Settings.TextAlignment == AlignmentType.Auto && !showGameIcon))
+        {
+            GameNameLabel.CalculateAlternateText(g, width - startPadding - titleEndPadding);
+            float stringWidth = GameNameLabel.ActualWidth;
+            PositionAndWidth positionAndWidth = calculateCenteredPositionAndWidth(width, stringWidth, startPadding, titleEndPadding);
+            GameNameLabel.X = positionAndWidth.position;
+            GameNameLabel.Width = positionAndWidth.width;
+        }
+        else
+        {
+            GameNameLabel.X = startPadding;
+            GameNameLabel.Width = width - startPadding - titleEndPadding;
+        }
+
+        GameNameLabel.HorizontalAlignment = StringAlignment.Near;
+        GameNameLabel.VerticalAlignment = string.IsNullOrEmpty(CategoryNameLabel.Text) ? StringAlignment.Center : StringAlignment.Near;
+        GameNameLabel.Y = 0;
+        GameNameLabel.Height = height;
+        GameNameLabel.Font = TitleFont;
+        GameNameLabel.Brush = new SolidBrush(Settings.OverrideTitleColor ? Settings.TitleColor : state.LayoutSettings.TextColor);
+        GameNameLabel.HasShadow = state.LayoutSettings.DropShadows;
+        GameNameLabel.ShadowColor = state.LayoutSettings.ShadowsColor;
+        GameNameLabel.OutlineColor = state.LayoutSettings.TextOutlineColor;
+        GameNameLabel.Draw(g);
+    }
+
+    private void DrawGameIcon(Graphics g, LiveSplitState state, float height)
+    {
+        var icon = state.Run.GameIcon;
+
+        if (OldImage != icon)
+        {
+            ImageAnimator.Animate(icon, (s, o) => { });
+            OldImage = icon;
+        }
+
+        var aspectRatio = (float)icon.Width / icon.Height;
+        var drawWidth = height - 4;
+        var drawHeight = height - 4;
+        if (icon.Width > icon.Height)
+        {
+            var ratio = icon.Height / (float)icon.Width;
+            drawHeight *= ratio;
+        }
+        else
+        {
+            var ratio = icon.Width / (float)icon.Height;
+            drawWidth *= ratio;
+        }
+
+        ImageAnimator.UpdateFrames(icon);
+
+        g.DrawImage(
+            icon,
+            7 + (height - 4 - drawWidth) / 2,
+            2 + (height - 4 - drawHeight) / 2,
+            drawWidth,
+            drawHeight);
+    }
+
+    /*
+     * Returns coordinate and width of the string element so that the text is centered in the total width
+     * while not overlapping into the start or ending padding.
+     */
+    private PositionAndWidth calculateCenteredPositionAndWidth(float totalWidth, float stringWidth, float startPadding, float endPadding)
+    {
+        float position, width;
+        if (startPadding + stringWidth + endPadding > totalWidth)
+        {
+            // We cant fit no matter what we do, so start the string after the start padding 
+            position = startPadding;
+        }
+        else
+        {
+            // Try to center, but push the string left or right if it overlaps the padding
+            position = (totalWidth - stringWidth) / 2;
+            position = Math.Max(position, startPadding);
+            if (position + stringWidth > totalWidth - endPadding)
+            {
+                position = totalWidth - endPadding - stringWidth;
+            }
+        }
+        width = totalWidth - endPadding - position;
+        return new PositionAndWidth(position, width);
+    }
+
+    private class PositionAndWidth
+    {
+        public float position { get; set; }
+        public float width { get; set; }
+        public PositionAndWidth(float position, float width)
+        {
+            this.position = position;
+            this.width = width;
+        }
+    }
+
+    public void DrawHorizontal(Graphics g, LiveSplitState state, float height, Region clipRegion)
+    {
+        DrawGeneral(g, state, HorizontalWidth, height, LayoutMode.Horizontal);
+    }
+
+    public void DrawVertical(Graphics g, LiveSplitState state, float width, Region clipRegion)
+    {
+        DrawGeneral(g, state, width, VerticalHeight, LayoutMode.Vertical);
+    }
+
+    public string ComponentName => "Title";
+
+    public Control GetSettingsControl(LayoutMode mode)
+    {
+        return Settings;
+    }
+
+    public XmlNode GetSettings(XmlDocument document)
+    {
+        return Settings.GetSettings(document);
+    }
+
+    public void SetSettings(XmlNode settings)
+    {
+        Settings.SetSettings(settings);
+    }
+
+    private IEnumerable<string> getCategoryNameAbbreviations(string categoryName)
+    {
+        var indexStart = categoryName.IndexOf('(');
+        var indexEnd = categoryName.IndexOf(')', indexStart + 1);
+        var afterParentheses = "";
+        if (indexStart >= 0 && indexEnd >= 0)
+        {
+            var inside = categoryName.Substring(indexStart + 1, indexEnd - indexStart - 1);
+            afterParentheses = categoryName.Substring(indexEnd + 1).Trim();
+            categoryName = categoryName.Substring(0, indexStart).Trim();
+            var splits = inside.Split(',');
+
+            for (var i = splits.Length - 1; i > 0; --i)
+            {
+                yield return $"{categoryName} ({string.Join(",", splits.Take(i))}) {afterParentheses}".Trim();
+            }
+        }
+        yield return $"{categoryName} {afterParentheses}".Trim();
+    }
+
+    public void Update(IInvalidator invalidator, LiveSplitState state, float width, float height, LayoutMode mode)
+    {
+        var extendedCategoryName = state.Run.GetExtendedCategoryName(Settings.ShowRegion, Settings.ShowPlatform, Settings.ShowVariables);
+
+        Cache.Restart();
+        Cache["SingleLine"] = Settings.SingleLine;
+        Cache["GameName"] = state.Run.GameName;
+        Cache["CategoryName"] = extendedCategoryName;
+        Cache["LayoutMode"] = mode;
+        Cache["ShowGameName"] = Settings.ShowGameName;
+        Cache["ShowCategoryName"] = Settings.ShowCategoryName;
+        if (Cache.HasChanged)
+        {
+            if (Settings.SingleLine && Settings.ShowGameName && Settings.ShowCategoryName)
+            {
+                var text = string.Format("{0} - {1}", state.Run.GameName, extendedCategoryName);
+                var gameAbbreviations = state.Run.GameName.GetAbbreviations();
+                var shortestGameName = gameAbbreviations.Last();
+                var categoryAbbreviations = getCategoryNameAbbreviations(extendedCategoryName);
+                var combinedAbbreviations1 = gameAbbreviations.Select(x => string.Format("{0} - {1}", x, extendedCategoryName));
+                var combinedAbbreviations2 = categoryAbbreviations.Select(x => string.Format("{0} - {1}", shortestGameName, x));
+                var abbreviations = combinedAbbreviations1.Concat(combinedAbbreviations2).ToList();
+                GameNameLabel.Text = text;
+                GameNameLabel.AlternateText = mode == LayoutMode.Vertical ? abbreviations : new List<string>();
+                CategoryNameLabel.Text = "";
+            }
+            else
+            {
+                if (Settings.ShowGameName)
+                {
+                    GameNameLabel.Text = state.Run.GameName;
+                    GameNameLabel.AlternateText = mode == LayoutMode.Vertical ? state.Run.GameName.GetAbbreviations().ToList() : new List<string>();
+                }
+                else
+                {
+                    GameNameLabel.Text = "";
+                    GameNameLabel.AlternateText = new List<string>();
+                }
+                if (Settings.ShowCategoryName)
+                {
+                    CategoryNameLabel.Text = extendedCategoryName;
+                    CategoryNameLabel.AlternateText = mode == LayoutMode.Vertical ? getCategoryNameAbbreviations(extendedCategoryName).ToList() : new List<string>();
+                }
+                else
+                {
+                    CategoryNameLabel.Text = "";
+                    CategoryNameLabel.AlternateText = new List<string>();
+                }
+            }
+        }
+
+        Cache.Restart();
+        Cache["AttemptHistoryCount"] = state.Run.AttemptHistory.Count;
+        Cache["Run"] = state.Run;
+        if (Cache.HasChanged)
+            FinishedRunsInHistory = state.Run.AttemptHistory.Where(x => x.Time.RealTime != null).Count();
+        var totalFinishedRunsCount = FinishedRunsInHistory + (state.CurrentPhase == TimerPhase.Ended ? 1 : 0);
+
+        if (Settings.ShowAttemptCount && Settings.ShowFinishedRunsCount)
+            AttemptCountLabel.Text = string.Format("{0}/{1}", totalFinishedRunsCount, state.Run.AttemptCount);
+        else if (Settings.ShowAttemptCount)
+            AttemptCountLabel.Text = state.Run.AttemptCount.ToString();
+        else if (Settings.ShowFinishedRunsCount)
+            AttemptCountLabel.Text = totalFinishedRunsCount.ToString();
+
+
+        Cache.Restart();
+        Cache["GameIcon"] = state.Run.GameIcon;
+        if (Cache.HasChanged)
+        {
+            if (state.Run.GameIcon == null)
+                FrameCount = 0;
+            else
+                FrameCount = state.Run.GameIcon.GetFrameCount(new FrameDimension(state.Run.GameIcon.FrameDimensionsList[0]));
+        }
+        Cache["GameNameLabel"] = GameNameLabel.Text;
+        Cache["CategoryNameLabel"] = CategoryNameLabel.Text;
+        Cache["AttemptCountLabel"] = AttemptCountLabel.Text;
+        Cache["TextAlignment"] = Settings.TextAlignment;
+
+        if (invalidator != null && (Cache.HasChanged || FrameCount > 1))
+        {
+            invalidator.Invalidate(0, 0, width, height);
+        }
+    }
+
+    public void Dispose()
+    {
+    }
+
+    public int GetSettingsHashCode() => Settings.GetSettingsHashCode();
 }

--- a/src/LiveSplit.Title/UI/Components/Title.cs
+++ b/src/LiveSplit.Title/UI/Components/Title.cs
@@ -398,7 +398,7 @@ public class Title : IComponent
         Cache["Run"] = state.Run;
         if (Cache.HasChanged)
         {
-            FinishedRunsInHistory = state.Run.AttemptHistory.Where(x => x.Time.RealTime != null).Count();
+            FinishedRunsInHistory = state.Run.AttemptHistory.Count(x => x.Time.RealTime != null);
         }
 
         var totalFinishedRunsCount = FinishedRunsInHistory + (state.CurrentPhase == TimerPhase.Ended ? 1 : 0);

--- a/src/LiveSplit.Title/UI/Components/Title.cs
+++ b/src/LiveSplit.Title/UI/Components/Title.cs
@@ -38,7 +38,7 @@ public class Title : IComponent
             }
 
             // The game name is longer than the category+attempts, so center the category, then add the attempts and compare with the game name.
-            float centeredCategoryWidth = GameNameLabel.ActualWidth / 2 + CategoryNameLabel.ActualWidth / 2 + AttemptCountLabel.ActualWidth;
+            float centeredCategoryWidth = (GameNameLabel.ActualWidth / 2) + (CategoryNameLabel.ActualWidth / 2) + AttemptCountLabel.ActualWidth;
             if (centeredCategoryWidth > GameNameLabel.ActualWidth)
             {
                 return centeredCategoryWidth + CategoryNameLabel.X + 5;
@@ -49,7 +49,6 @@ public class Title : IComponent
             }
         }
     }
-
 
     public IDictionary<string, Action> ContextMenuControls => null;
 
@@ -81,9 +80,13 @@ public class Title : IComponent
         DrawBackground(g, width, height);
 
         if (Settings.OverrideTitleFont)
+        {
             TitleFont = Settings.TitleFont;
+        }
         else
+        {
             TitleFont = state.LayoutSettings.TextFont;
+        }
 
         MinimumHeight = g.MeasureString("A", TitleFont).Height * 1.7f;
         VerticalHeight = g.MeasureString("A", TitleFont).Height * 1.7f;
@@ -105,8 +108,8 @@ public class Title : IComponent
     private void DrawBackground(Graphics g, float width, float height)
     {
         if (Settings.BackgroundColor.A > 0
-            || Settings.BackgroundGradient != GradientType.Plain
-            && Settings.BackgroundColor2.A > 0)
+            || (Settings.BackgroundGradient != GradientType.Plain
+            && Settings.BackgroundColor2.A > 0))
         {
             var gradientBrush = new LinearGradientBrush(
                         new PointF(0, 0),
@@ -130,6 +133,7 @@ public class Title : IComponent
         {
             startPadding += height + 3;
         }
+
         if (mode == LayoutMode.Vertical && Settings.ShowCount)
         {
             if (string.IsNullOrEmpty(CategoryNameLabel.Text))
@@ -158,6 +162,7 @@ public class Title : IComponent
             CategoryNameLabel.X = startPadding;
             CategoryNameLabel.Width = width - startPadding - categoryEndPadding;
         }
+
         CategoryNameLabel.Y = 0;
         CategoryNameLabel.HorizontalAlignment = StringAlignment.Near;
         CategoryNameLabel.VerticalAlignment = string.IsNullOrEmpty(GameNameLabel.Text) ? StringAlignment.Center : StringAlignment.Far;
@@ -245,8 +250,8 @@ public class Title : IComponent
 
         g.DrawImage(
             icon,
-            7 + (height - 4 - drawWidth) / 2,
-            2 + (height - 4 - drawHeight) / 2,
+            7 + ((height - 4 - drawWidth) / 2),
+            2 + ((height - 4 - drawHeight) / 2),
             drawWidth,
             drawHeight);
     }
@@ -273,6 +278,7 @@ public class Title : IComponent
                 position = totalWidth - endPadding - stringWidth;
             }
         }
+
         width = totalWidth - endPadding - position;
         return new PositionAndWidth(position, width);
     }
@@ -332,6 +338,7 @@ public class Title : IComponent
                 yield return $"{categoryName} ({string.Join(",", splits.Take(i))}) {afterParentheses}".Trim();
             }
         }
+
         yield return $"{categoryName} {afterParentheses}".Trim();
     }
 
@@ -373,6 +380,7 @@ public class Title : IComponent
                     GameNameLabel.Text = "";
                     GameNameLabel.AlternateText = new List<string>();
                 }
+
                 if (Settings.ShowCategoryName)
                 {
                     CategoryNameLabel.Text = extendedCategoryName;
@@ -390,26 +398,39 @@ public class Title : IComponent
         Cache["AttemptHistoryCount"] = state.Run.AttemptHistory.Count;
         Cache["Run"] = state.Run;
         if (Cache.HasChanged)
+        {
             FinishedRunsInHistory = state.Run.AttemptHistory.Where(x => x.Time.RealTime != null).Count();
+        }
+
         var totalFinishedRunsCount = FinishedRunsInHistory + (state.CurrentPhase == TimerPhase.Ended ? 1 : 0);
 
         if (Settings.ShowAttemptCount && Settings.ShowFinishedRunsCount)
+        {
             AttemptCountLabel.Text = string.Format("{0}/{1}", totalFinishedRunsCount, state.Run.AttemptCount);
+        }
         else if (Settings.ShowAttemptCount)
+        {
             AttemptCountLabel.Text = state.Run.AttemptCount.ToString();
+        }
         else if (Settings.ShowFinishedRunsCount)
+        {
             AttemptCountLabel.Text = totalFinishedRunsCount.ToString();
-
+        }
 
         Cache.Restart();
         Cache["GameIcon"] = state.Run.GameIcon;
         if (Cache.HasChanged)
         {
             if (state.Run.GameIcon == null)
+            {
                 FrameCount = 0;
+            }
             else
+            {
                 FrameCount = state.Run.GameIcon.GetFrameCount(new FrameDimension(state.Run.GameIcon.FrameDimensionsList[0]));
+            }
         }
+
         Cache["GameNameLabel"] = GameNameLabel.Text;
         Cache["CategoryNameLabel"] = CategoryNameLabel.Text;
         Cache["AttemptCountLabel"] = AttemptCountLabel.Text;

--- a/src/LiveSplit.Title/UI/Components/Title.cs
+++ b/src/LiveSplit.Title/UI/Components/Title.cs
@@ -57,9 +57,9 @@ public class Title : IComponent
     public float PaddingBottom => 0f;
     public float PaddingRight => 7f;
 
-    protected SimpleLabel GameNameLabel = new SimpleLabel();
-    protected SimpleLabel CategoryNameLabel = new SimpleLabel();
-    protected SimpleLabel AttemptCountLabel = new SimpleLabel();
+    protected SimpleLabel GameNameLabel = new();
+    protected SimpleLabel CategoryNameLabel = new();
+    protected SimpleLabel AttemptCountLabel = new();
 
     protected Font TitleFont { get; set; }
 
@@ -90,7 +90,7 @@ public class Title : IComponent
 
         MinimumHeight = g.MeasureString("A", TitleFont).Height * 1.7f;
         VerticalHeight = g.MeasureString("A", TitleFont).Height * 1.7f;
-        var showGameIcon = state.Run.GameIcon != null && Settings.DisplayGameIcon;
+        bool showGameIcon = state.Run.GameIcon != null && Settings.DisplayGameIcon;
         if (showGameIcon)
         {
             DrawGameIcon(g, state, height);
@@ -223,7 +223,7 @@ public class Title : IComponent
 
     private void DrawGameIcon(Graphics g, LiveSplitState state, float height)
     {
-        var icon = state.Run.GameIcon;
+        Image icon = state.Run.GameIcon;
 
         if (OldImage != icon)
         {
@@ -231,17 +231,17 @@ public class Title : IComponent
             OldImage = icon;
         }
 
-        var aspectRatio = (float)icon.Width / icon.Height;
-        var drawWidth = height - 4;
-        var drawHeight = height - 4;
+        float aspectRatio = (float)icon.Width / icon.Height;
+        float drawWidth = height - 4;
+        float drawHeight = height - 4;
         if (icon.Width > icon.Height)
         {
-            var ratio = icon.Height / (float)icon.Width;
+            float ratio = icon.Height / (float)icon.Width;
             drawHeight *= ratio;
         }
         else
         {
-            var ratio = icon.Width / (float)icon.Height;
+            float ratio = icon.Width / (float)icon.Height;
             drawWidth *= ratio;
         }
 
@@ -322,17 +322,17 @@ public class Title : IComponent
 
     private IEnumerable<string> getCategoryNameAbbreviations(string categoryName)
     {
-        var indexStart = categoryName.IndexOf('(');
-        var indexEnd = categoryName.IndexOf(')', indexStart + 1);
-        var afterParentheses = "";
+        int indexStart = categoryName.IndexOf('(');
+        int indexEnd = categoryName.IndexOf(')', indexStart + 1);
+        string afterParentheses = "";
         if (indexStart >= 0 && indexEnd >= 0)
         {
-            var inside = categoryName.Substring(indexStart + 1, indexEnd - indexStart - 1);
+            string inside = categoryName.Substring(indexStart + 1, indexEnd - indexStart - 1);
             afterParentheses = categoryName.Substring(indexEnd + 1).Trim();
             categoryName = categoryName.Substring(0, indexStart).Trim();
-            var splits = inside.Split(',');
+            string[] splits = inside.Split(',');
 
-            for (var i = splits.Length - 1; i > 0; --i)
+            for (int i = splits.Length - 1; i > 0; --i)
             {
                 yield return $"{categoryName} ({string.Join(",", splits.Take(i))}) {afterParentheses}".Trim();
             }
@@ -343,7 +343,7 @@ public class Title : IComponent
 
     public void Update(IInvalidator invalidator, LiveSplitState state, float width, float height, LayoutMode mode)
     {
-        var extendedCategoryName = state.Run.GetExtendedCategoryName(Settings.ShowRegion, Settings.ShowPlatform, Settings.ShowVariables);
+        string extendedCategoryName = state.Run.GetExtendedCategoryName(Settings.ShowRegion, Settings.ShowPlatform, Settings.ShowVariables);
 
         Cache.Restart();
         Cache["SingleLine"] = Settings.SingleLine;
@@ -356,12 +356,12 @@ public class Title : IComponent
         {
             if (Settings.SingleLine && Settings.ShowGameName && Settings.ShowCategoryName)
             {
-                var text = string.Format("{0} - {1}", state.Run.GameName, extendedCategoryName);
-                var gameAbbreviations = state.Run.GameName.GetAbbreviations();
-                var shortestGameName = gameAbbreviations.Last();
-                var categoryAbbreviations = getCategoryNameAbbreviations(extendedCategoryName);
-                var combinedAbbreviations1 = gameAbbreviations.Select(x => string.Format("{0} - {1}", x, extendedCategoryName));
-                var combinedAbbreviations2 = categoryAbbreviations.Select(x => string.Format("{0} - {1}", shortestGameName, x));
+                string text = string.Format("{0} - {1}", state.Run.GameName, extendedCategoryName);
+                IEnumerable<string> gameAbbreviations = state.Run.GameName.GetAbbreviations();
+                string shortestGameName = gameAbbreviations.Last();
+                IEnumerable<string> categoryAbbreviations = getCategoryNameAbbreviations(extendedCategoryName);
+                IEnumerable<string> combinedAbbreviations1 = gameAbbreviations.Select(x => string.Format("{0} - {1}", x, extendedCategoryName));
+                IEnumerable<string> combinedAbbreviations2 = categoryAbbreviations.Select(x => string.Format("{0} - {1}", shortestGameName, x));
                 var abbreviations = combinedAbbreviations1.Concat(combinedAbbreviations2).ToList();
                 GameNameLabel.Text = text;
                 GameNameLabel.AlternateText = mode == LayoutMode.Vertical ? abbreviations : [];
@@ -401,7 +401,7 @@ public class Title : IComponent
             FinishedRunsInHistory = state.Run.AttemptHistory.Count(x => x.Time.RealTime != null);
         }
 
-        var totalFinishedRunsCount = FinishedRunsInHistory + (state.CurrentPhase == TimerPhase.Ended ? 1 : 0);
+        int totalFinishedRunsCount = FinishedRunsInHistory + (state.CurrentPhase == TimerPhase.Ended ? 1 : 0);
 
         if (Settings.ShowAttemptCount && Settings.ShowFinishedRunsCount)
         {

--- a/src/LiveSplit.Title/UI/Components/Title.cs
+++ b/src/LiveSplit.Title/UI/Components/Title.cs
@@ -328,8 +328,8 @@ public class Title : IComponent
         if (indexStart >= 0 && indexEnd >= 0)
         {
             string inside = categoryName.Substring(indexStart + 1, indexEnd - indexStart - 1);
-            afterParentheses = categoryName.Substring(indexEnd + 1).Trim();
-            categoryName = categoryName.Substring(0, indexStart).Trim();
+            afterParentheses = categoryName[(indexEnd + 1)..].Trim();
+            categoryName = categoryName[..indexStart].Trim();
             string[] splits = inside.Split(',');
 
             for (int i = splits.Length - 1; i > 0; --i)

--- a/src/LiveSplit.Title/UI/Components/Title.cs
+++ b/src/LiveSplit.Title/UI/Components/Title.cs
@@ -365,7 +365,7 @@ public class Title : IComponent
                 var combinedAbbreviations2 = categoryAbbreviations.Select(x => string.Format("{0} - {1}", shortestGameName, x));
                 var abbreviations = combinedAbbreviations1.Concat(combinedAbbreviations2).ToList();
                 GameNameLabel.Text = text;
-                GameNameLabel.AlternateText = mode == LayoutMode.Vertical ? abbreviations : new List<string>();
+                GameNameLabel.AlternateText = mode == LayoutMode.Vertical ? abbreviations : [];
                 CategoryNameLabel.Text = "";
             }
             else
@@ -373,23 +373,23 @@ public class Title : IComponent
                 if (Settings.ShowGameName)
                 {
                     GameNameLabel.Text = state.Run.GameName;
-                    GameNameLabel.AlternateText = mode == LayoutMode.Vertical ? state.Run.GameName.GetAbbreviations().ToList() : new List<string>();
+                    GameNameLabel.AlternateText = mode == LayoutMode.Vertical ? state.Run.GameName.GetAbbreviations().ToList() : [];
                 }
                 else
                 {
                     GameNameLabel.Text = "";
-                    GameNameLabel.AlternateText = new List<string>();
+                    GameNameLabel.AlternateText = [];
                 }
 
                 if (Settings.ShowCategoryName)
                 {
                     CategoryNameLabel.Text = extendedCategoryName;
-                    CategoryNameLabel.AlternateText = mode == LayoutMode.Vertical ? getCategoryNameAbbreviations(extendedCategoryName).ToList() : new List<string>();
+                    CategoryNameLabel.AlternateText = mode == LayoutMode.Vertical ? getCategoryNameAbbreviations(extendedCategoryName).ToList() : [];
                 }
                 else
                 {
                     CategoryNameLabel.Text = "";
-                    CategoryNameLabel.AlternateText = new List<string>();
+                    CategoryNameLabel.AlternateText = [];
                 }
             }
         }

--- a/src/LiveSplit.Title/UI/Components/TitleFactory.cs
+++ b/src/LiveSplit.Title/UI/Components/TitleFactory.cs
@@ -1,27 +1,27 @@
-﻿using LiveSplit.Model;
+﻿using System;
+
+using LiveSplit.Model;
 using LiveSplit.UI.Components;
-using System;
 
 [assembly: ComponentFactory(typeof(TitleFactory))]
 
-namespace LiveSplit.UI.Components
+namespace LiveSplit.UI.Components;
+
+public class TitleFactory : IComponentFactory
 {
-    public class TitleFactory : IComponentFactory
-    {
-        public string ComponentName => "Title";
+    public string ComponentName => "Title";
 
-        public string Description => "Shows the current run title, run category, and game icon.";
+    public string Description => "Shows the current run title, run category, and game icon.";
 
-        public ComponentCategory Category => ComponentCategory.Information;
+    public ComponentCategory Category => ComponentCategory.Information;
 
-        public IComponent Create(LiveSplitState state) => new Title();
+    public IComponent Create(LiveSplitState state) => new Title();
 
-        public string UpdateName => ComponentName;
+    public string UpdateName => ComponentName;
 
-        public string XMLURL => "http://livesplit.org/update/Components/update.LiveSplit.Title.xml";
+    public string XMLURL => "http://livesplit.org/update/Components/update.LiveSplit.Title.xml";
 
-        public string UpdateURL => "http://livesplit.org/update/";
+    public string UpdateURL => "http://livesplit.org/update/";
 
-        public Version Version => Version.Parse("1.8.29");
-    }
+    public Version Version => Version.Parse("1.8.29");
 }

--- a/src/LiveSplit.Title/UI/Components/TitleFactory.cs
+++ b/src/LiveSplit.Title/UI/Components/TitleFactory.cs
@@ -15,7 +15,10 @@ public class TitleFactory : IComponentFactory
 
     public ComponentCategory Category => ComponentCategory.Information;
 
-    public IComponent Create(LiveSplitState state) => new Title();
+    public IComponent Create(LiveSplitState state)
+    {
+        return new Title();
+    }
 
     public string UpdateName => ComponentName;
 

--- a/src/LiveSplit.Title/UI/Components/TitleSettings.cs
+++ b/src/LiveSplit.Title/UI/Components/TitleSettings.cs
@@ -3,199 +3,198 @@ using System.Drawing;
 using System.Windows.Forms;
 using System.Xml;
 
-namespace LiveSplit.UI.Components
+namespace LiveSplit.UI.Components;
+
+public partial class TitleSettings : UserControl
 {
-    public partial class TitleSettings : UserControl
+    public bool ShowGameName { get; set; }
+    public bool ShowCategoryName { get; set; }
+    public bool ShowAttemptCount { get; set; }
+    public bool ShowFinishedRunsCount { get; set; }
+    public bool ShowCount => ShowAttemptCount || ShowFinishedRunsCount;
+    public AlignmentType TextAlignment { get; set; }
+    public bool SingleLine { get; set; }
+    public bool DisplayGameIcon { get; set; }
+
+    public bool ShowRegion { get; set; }
+    public bool ShowPlatform { get; set; }
+    public bool ShowVariables { get; set; }
+
+    public Color TitleColor { get; set; }
+    public bool OverrideTitleColor { get; set; }
+
+    public string TitleFontString => SettingsHelper.FormatFont(TitleFont);
+
+    public Font TitleFont { get; set; }
+    public bool OverrideTitleFont { get; set; }
+
+    public Color BackgroundColor { get; set; }
+    public Color BackgroundColor2 { get; set; }
+    public GradientType BackgroundGradient { get; set; }
+    public string GradientString
     {
-        public bool ShowGameName { get; set; }
-        public bool ShowCategoryName { get; set; }
-        public bool ShowAttemptCount { get; set; }
-        public bool ShowFinishedRunsCount { get; set; }
-        public bool ShowCount => ShowAttemptCount || ShowFinishedRunsCount;
-        public AlignmentType TextAlignment { get; set; }
-        public bool SingleLine { get; set; }
-        public bool DisplayGameIcon { get; set; }
+        get { return BackgroundGradient.ToString(); }
+        set { BackgroundGradient = (GradientType)Enum.Parse(typeof(GradientType), value); }
+    }
 
-        public bool ShowRegion { get; set; }
-        public bool ShowPlatform { get; set; }
-        public bool ShowVariables { get; set; }
+    public TitleSettings()
+    {
+        InitializeComponent();
+        ShowGameName = true;
+        ShowCategoryName = true;
+        ShowAttemptCount = true;
+        ShowFinishedRunsCount = false;
+        DisplayGameIcon = true;
+        TitleFont = new Font("Segoe UI", 16, FontStyle.Regular, GraphicsUnit.Pixel);
+        OverrideTitleFont = false;
+        TitleColor = Color.FromArgb(255, 255, 255, 255);
+        OverrideTitleColor = false;
+        SingleLine = false;
+        ShowRegion = false;
+        ShowPlatform = false;
+        ShowVariables = true;
+        BackgroundColor = Color.FromArgb(255, 42, 42, 42);
+        BackgroundColor2 = Color.FromArgb(255, 19, 19, 19);
+        BackgroundGradient = GradientType.Vertical;
+        TextAlignment = AlignmentType.Auto;
 
-        public Color TitleColor { get; set; }
-        public bool OverrideTitleColor { get; set; }
+        chkGameName.DataBindings.Add("Checked", this, "ShowGameName", false, DataSourceUpdateMode.OnPropertyChanged);
+        chkCategoryName.DataBindings.Add("Checked", this, "ShowCategoryName", false, DataSourceUpdateMode.OnPropertyChanged);
+        chkAttemptCount.DataBindings.Add("Checked", this, "ShowAttemptCount", false, DataSourceUpdateMode.OnPropertyChanged);
+        chkFinishedRuns.DataBindings.Add("Checked", this, "ShowFinishedRunsCount", false, DataSourceUpdateMode.OnPropertyChanged);
+        chkFont.DataBindings.Add("Checked", this, "OverrideTitleFont", false, DataSourceUpdateMode.OnPropertyChanged);
+        lblFont.DataBindings.Add("Text", this, "TitleFontString", false, DataSourceUpdateMode.OnPropertyChanged);
+        chkColor.DataBindings.Add("Checked", this, "OverrideTitleColor", false, DataSourceUpdateMode.OnPropertyChanged);
+        chkSingleLine.DataBindings.Add("Checked", this, "SingleLine", false, DataSourceUpdateMode.OnPropertyChanged);
+        btnColor.DataBindings.Add("BackColor", this, "TitleColor", false, DataSourceUpdateMode.OnPropertyChanged);
+        btnColor1.DataBindings.Add("BackColor", this, "BackgroundColor", false, DataSourceUpdateMode.OnPropertyChanged);
+        btnColor2.DataBindings.Add("BackColor", this, "BackgroundColor2", false, DataSourceUpdateMode.OnPropertyChanged);
+        chkDisplayGameIcon.DataBindings.Add("Checked", this, "DisplayGameIcon", false, DataSourceUpdateMode.OnPropertyChanged);
+        cmbGradientType.DataBindings.Add("SelectedItem", this, "GradientString", false, DataSourceUpdateMode.OnPropertyChanged);
+        chkRegion.DataBindings.Add("Checked", this, "ShowRegion", false, DataSourceUpdateMode.OnPropertyChanged);
+        chkPlatform.DataBindings.Add("Checked", this, "ShowPlatform", false, DataSourceUpdateMode.OnPropertyChanged);
+        chkVariables.DataBindings.Add("Checked", this, "ShowVariables", false, DataSourceUpdateMode.OnPropertyChanged);
+    }
 
-        public string TitleFontString => SettingsHelper.FormatFont(TitleFont);
+    void TitleSettings_Load(object sender, EventArgs e)
+    {
+        chkColor_CheckedChanged(null, null);
+        chkFont_CheckedChanged(null, null);
+        cmbTextAlignment.SelectedIndex = (int)TextAlignment;
+    }
 
-        public Font TitleFont { get; set; }
-        public bool OverrideTitleFont { get; set; }
+    void chkColor_CheckedChanged(object sender, EventArgs e)
+    {
+        label3.Enabled = btnColor.Enabled = chkColor.Checked;
+    }
 
-        public Color BackgroundColor { get; set; }
-        public Color BackgroundColor2 { get; set; }
-        public GradientType BackgroundGradient { get; set; }
-        public string GradientString
+    void chkFont_CheckedChanged(object sender, EventArgs e)
+    {
+        label1.Enabled = lblFont.Enabled = btnFont.Enabled = chkFont.Checked;
+    }
+
+    void cmbGradientType_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        btnColor1.Visible = cmbGradientType.SelectedItem.ToString() != "Plain";
+        btnColor2.DataBindings.Clear();
+        btnColor2.DataBindings.Add("BackColor", this, btnColor1.Visible ? "BackgroundColor2" : "BackgroundColor", false, DataSourceUpdateMode.OnPropertyChanged);
+        GradientString = cmbGradientType.SelectedItem.ToString();
+    }
+
+    void cmbTextAlignment_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        TextAlignment = (AlignmentType)cmbTextAlignment.SelectedIndex;
+    }
+
+    public void SetSettings(XmlNode node)
+    {
+        var element = (XmlElement)node;
+        Version version = SettingsHelper.ParseVersion(element["Version"]);
+        DisplayGameIcon = SettingsHelper.ParseBool(element["DisplayGameIcon"], true);
+
+        if (version >= new Version(1, 2))
         {
-            get { return BackgroundGradient.ToString(); }
-            set { BackgroundGradient = (GradientType)Enum.Parse(typeof(GradientType), value); }
-        }
-
-        public TitleSettings()
-        {
-            InitializeComponent();
-            ShowGameName = true;
-            ShowCategoryName = true;
-            ShowAttemptCount = true;
-            ShowFinishedRunsCount = false;
-            DisplayGameIcon = true;
-            TitleFont = new Font("Segoe UI", 16, FontStyle.Regular, GraphicsUnit.Pixel);
-            OverrideTitleFont = false;
-            TitleColor = Color.FromArgb(255, 255, 255, 255);
-            OverrideTitleColor = false;
-            SingleLine = false;
-            ShowRegion = false;
-            ShowPlatform = false;
-            ShowVariables = true;
-            BackgroundColor = Color.FromArgb(255, 42, 42, 42);
-            BackgroundColor2 = Color.FromArgb(255, 19, 19, 19);
-            BackgroundGradient = GradientType.Vertical;
-            TextAlignment = AlignmentType.Auto;
-
-            chkGameName.DataBindings.Add("Checked", this, "ShowGameName", false, DataSourceUpdateMode.OnPropertyChanged);
-            chkCategoryName.DataBindings.Add("Checked", this, "ShowCategoryName", false, DataSourceUpdateMode.OnPropertyChanged);
-            chkAttemptCount.DataBindings.Add("Checked", this, "ShowAttemptCount", false, DataSourceUpdateMode.OnPropertyChanged);
-            chkFinishedRuns.DataBindings.Add("Checked", this, "ShowFinishedRunsCount", false, DataSourceUpdateMode.OnPropertyChanged);
-            chkFont.DataBindings.Add("Checked", this, "OverrideTitleFont", false, DataSourceUpdateMode.OnPropertyChanged);
-            lblFont.DataBindings.Add("Text", this, "TitleFontString", false, DataSourceUpdateMode.OnPropertyChanged);
-            chkColor.DataBindings.Add("Checked", this, "OverrideTitleColor", false, DataSourceUpdateMode.OnPropertyChanged);
-            chkSingleLine.DataBindings.Add("Checked", this, "SingleLine", false, DataSourceUpdateMode.OnPropertyChanged);
-            btnColor.DataBindings.Add("BackColor", this, "TitleColor", false, DataSourceUpdateMode.OnPropertyChanged);
-            btnColor1.DataBindings.Add("BackColor", this, "BackgroundColor", false, DataSourceUpdateMode.OnPropertyChanged);
-            btnColor2.DataBindings.Add("BackColor", this, "BackgroundColor2", false, DataSourceUpdateMode.OnPropertyChanged);
-            chkDisplayGameIcon.DataBindings.Add("Checked", this, "DisplayGameIcon", false, DataSourceUpdateMode.OnPropertyChanged);
-            cmbGradientType.DataBindings.Add("SelectedItem", this, "GradientString", false, DataSourceUpdateMode.OnPropertyChanged);
-            chkRegion.DataBindings.Add("Checked", this, "ShowRegion", false, DataSourceUpdateMode.OnPropertyChanged);
-            chkPlatform.DataBindings.Add("Checked", this, "ShowPlatform", false, DataSourceUpdateMode.OnPropertyChanged);
-            chkVariables.DataBindings.Add("Checked", this, "ShowVariables", false, DataSourceUpdateMode.OnPropertyChanged);
-        }
-
-        void TitleSettings_Load(object sender, EventArgs e)
-        {
-            chkColor_CheckedChanged(null, null);
-            chkFont_CheckedChanged(null, null);
-            cmbTextAlignment.SelectedIndex = (int)TextAlignment;
-        }
-
-        void chkColor_CheckedChanged(object sender, EventArgs e)
-        {
-            label3.Enabled = btnColor.Enabled = chkColor.Checked;
-        }
-
-        void chkFont_CheckedChanged(object sender, EventArgs e)
-        {
-            label1.Enabled = lblFont.Enabled = btnFont.Enabled = chkFont.Checked;
-        }
-
-        void cmbGradientType_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            btnColor1.Visible = cmbGradientType.SelectedItem.ToString() != "Plain";
-            btnColor2.DataBindings.Clear();
-            btnColor2.DataBindings.Add("BackColor", this, btnColor1.Visible ? "BackgroundColor2" : "BackgroundColor", false, DataSourceUpdateMode.OnPropertyChanged);
-            GradientString = cmbGradientType.SelectedItem.ToString();
-        }
-
-        void cmbTextAlignment_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            TextAlignment = (AlignmentType)cmbTextAlignment.SelectedIndex;
-        }
-
-        public void SetSettings(XmlNode node)
-        {
-            var element = (XmlElement)node;
-            Version version = SettingsHelper.ParseVersion(element["Version"]);
-            DisplayGameIcon = SettingsHelper.ParseBool(element["DisplayGameIcon"], true);
-
-            if (version >= new Version(1, 2))
+            TitleFont = SettingsHelper.GetFontFromElement(element["TitleFont"]);
+            if (version >= new Version(1, 3))
             {
-                TitleFont = SettingsHelper.GetFontFromElement(element["TitleFont"]);
-                if (version >= new Version(1, 3))
+                OverrideTitleFont = SettingsHelper.ParseBool(element["OverrideTitleFont"]);
+                if (version >= new Version(1, 7, 3))
                 {
-                    OverrideTitleFont = SettingsHelper.ParseBool(element["OverrideTitleFont"]);
-                    if (version >= new Version(1, 7, 3))
-                    {
-                        TextAlignment = (AlignmentType)SettingsHelper.ParseInt(element["TextAlignment"], 0);
-                    }
-                    else
-                    {
-                        if (DisplayGameIcon && SettingsHelper.ParseBool(element["CenterTitle"], false))
-                            TextAlignment = AlignmentType.Center;
-                        else
-                            TextAlignment = AlignmentType.Auto;
-                    }
+                    TextAlignment = (AlignmentType)SettingsHelper.ParseInt(element["TextAlignment"], 0);
                 }
                 else
-                    OverrideTitleFont = !SettingsHelper.ParseBool(element["UseLayoutSettingsFont"]);
+                {
+                    if (DisplayGameIcon && SettingsHelper.ParseBool(element["CenterTitle"], false))
+                        TextAlignment = AlignmentType.Center;
+                    else
+                        TextAlignment = AlignmentType.Auto;
+                }
             }
             else
-            {
-                TitleFont = new Font("Segoe UI", 13, FontStyle.Regular, GraphicsUnit.Pixel);
-                OverrideTitleFont = false;
-            }
-
-            ShowGameName = SettingsHelper.ParseBool(element["ShowGameName"], true);
-            ShowCategoryName = SettingsHelper.ParseBool(element["ShowCategoryName"], true);
-            ShowAttemptCount = SettingsHelper.ParseBool(element["ShowAttemptCount"]);
-            TitleColor = SettingsHelper.ParseColor(element["TitleColor"], Color.FromArgb(255, 255, 255, 255));
-            OverrideTitleColor = SettingsHelper.ParseBool(element["OverrideTitleColor"], false);
-            BackgroundColor = SettingsHelper.ParseColor(element["BackgroundColor"], Color.FromArgb(42, 42, 42, 255));
-            BackgroundColor2 = SettingsHelper.ParseColor(element["BackgroundColor2"], Color.FromArgb(19, 19, 19, 255));
-            GradientString = SettingsHelper.ParseString(element["BackgroundGradient"], GradientType.Vertical.ToString());
-            ShowFinishedRunsCount = SettingsHelper.ParseBool(element["ShowFinishedRunsCount"], false);
-            SingleLine = SettingsHelper.ParseBool(element["SingleLine"], false);
-            ShowRegion = SettingsHelper.ParseBool(element["ShowRegion"], false);
-            ShowPlatform = SettingsHelper.ParseBool(element["ShowPlatform"], false);
-            ShowVariables = SettingsHelper.ParseBool(element["ShowVariables"], true);
+                OverrideTitleFont = !SettingsHelper.ParseBool(element["UseLayoutSettingsFont"]);
         }
-
-        public XmlNode GetSettings(XmlDocument document)
+        else
         {
-            var parent = document.CreateElement("Settings");
-            CreateSettingsNode(document, parent);
-            return parent;
+            TitleFont = new Font("Segoe UI", 13, FontStyle.Regular, GraphicsUnit.Pixel);
+            OverrideTitleFont = false;
         }
 
-        public int GetSettingsHashCode() => CreateSettingsNode(null, null);
+        ShowGameName = SettingsHelper.ParseBool(element["ShowGameName"], true);
+        ShowCategoryName = SettingsHelper.ParseBool(element["ShowCategoryName"], true);
+        ShowAttemptCount = SettingsHelper.ParseBool(element["ShowAttemptCount"]);
+        TitleColor = SettingsHelper.ParseColor(element["TitleColor"], Color.FromArgb(255, 255, 255, 255));
+        OverrideTitleColor = SettingsHelper.ParseBool(element["OverrideTitleColor"], false);
+        BackgroundColor = SettingsHelper.ParseColor(element["BackgroundColor"], Color.FromArgb(42, 42, 42, 255));
+        BackgroundColor2 = SettingsHelper.ParseColor(element["BackgroundColor2"], Color.FromArgb(19, 19, 19, 255));
+        GradientString = SettingsHelper.ParseString(element["BackgroundGradient"], GradientType.Vertical.ToString());
+        ShowFinishedRunsCount = SettingsHelper.ParseBool(element["ShowFinishedRunsCount"], false);
+        SingleLine = SettingsHelper.ParseBool(element["SingleLine"], false);
+        ShowRegion = SettingsHelper.ParseBool(element["ShowRegion"], false);
+        ShowPlatform = SettingsHelper.ParseBool(element["ShowPlatform"], false);
+        ShowVariables = SettingsHelper.ParseBool(element["ShowVariables"], true);
+    }
 
-        private int CreateSettingsNode(XmlDocument document, XmlElement parent)
-        {
-            return SettingsHelper.CreateSetting(document, parent, "Version", "1.7.3") ^
-            SettingsHelper.CreateSetting(document, parent, "ShowGameName", ShowGameName) ^
-            SettingsHelper.CreateSetting(document, parent, "ShowCategoryName", ShowCategoryName) ^
-            SettingsHelper.CreateSetting(document, parent, "ShowAttemptCount", ShowAttemptCount) ^
-            SettingsHelper.CreateSetting(document, parent, "ShowFinishedRunsCount", ShowFinishedRunsCount) ^
-            SettingsHelper.CreateSetting(document, parent, "OverrideTitleFont", OverrideTitleFont) ^
-            SettingsHelper.CreateSetting(document, parent, "OverrideTitleColor", OverrideTitleColor) ^
-            SettingsHelper.CreateSetting(document, parent, "TitleFont", TitleFont) ^
-            SettingsHelper.CreateSetting(document, parent, "SingleLine", SingleLine) ^
-            SettingsHelper.CreateSetting(document, parent, "TitleColor", TitleColor) ^
-            SettingsHelper.CreateSetting(document, parent, "BackgroundColor", BackgroundColor) ^
-            SettingsHelper.CreateSetting(document, parent, "BackgroundColor2", BackgroundColor2) ^
-            SettingsHelper.CreateSetting(document, parent, "BackgroundGradient", BackgroundGradient) ^
-            SettingsHelper.CreateSetting(document, parent, "DisplayGameIcon", DisplayGameIcon) ^
-            SettingsHelper.CreateSetting(document, parent, "ShowRegion", ShowRegion) ^
-            SettingsHelper.CreateSetting(document, parent, "ShowPlatform", ShowPlatform) ^
-            SettingsHelper.CreateSetting(document, parent, "ShowVariables", ShowVariables) ^
-            SettingsHelper.CreateSetting(document, parent, "TextAlignment", (int)TextAlignment);
-        }
+    public XmlNode GetSettings(XmlDocument document)
+    {
+        var parent = document.CreateElement("Settings");
+        CreateSettingsNode(document, parent);
+        return parent;
+    }
 
-        private void btnFont_Click(object sender, EventArgs e)
-        {
-            var dialog = SettingsHelper.GetFontDialog(TitleFont, 11, 26);
-            dialog.FontChanged += (s, ev) => TitleFont = ((CustomFontDialog.FontChangedEventArgs)ev).NewFont;
-            dialog.ShowDialog(this);
-            lblFont.Text = TitleFontString;
-        }
+    public int GetSettingsHashCode() => CreateSettingsNode(null, null);
 
-        private void ColorButtonClick(object sender, EventArgs e)
-        {
-            SettingsHelper.ColorButtonClick((Button)sender, this);
-        }
+    private int CreateSettingsNode(XmlDocument document, XmlElement parent)
+    {
+        return SettingsHelper.CreateSetting(document, parent, "Version", "1.7.3") ^
+        SettingsHelper.CreateSetting(document, parent, "ShowGameName", ShowGameName) ^
+        SettingsHelper.CreateSetting(document, parent, "ShowCategoryName", ShowCategoryName) ^
+        SettingsHelper.CreateSetting(document, parent, "ShowAttemptCount", ShowAttemptCount) ^
+        SettingsHelper.CreateSetting(document, parent, "ShowFinishedRunsCount", ShowFinishedRunsCount) ^
+        SettingsHelper.CreateSetting(document, parent, "OverrideTitleFont", OverrideTitleFont) ^
+        SettingsHelper.CreateSetting(document, parent, "OverrideTitleColor", OverrideTitleColor) ^
+        SettingsHelper.CreateSetting(document, parent, "TitleFont", TitleFont) ^
+        SettingsHelper.CreateSetting(document, parent, "SingleLine", SingleLine) ^
+        SettingsHelper.CreateSetting(document, parent, "TitleColor", TitleColor) ^
+        SettingsHelper.CreateSetting(document, parent, "BackgroundColor", BackgroundColor) ^
+        SettingsHelper.CreateSetting(document, parent, "BackgroundColor2", BackgroundColor2) ^
+        SettingsHelper.CreateSetting(document, parent, "BackgroundGradient", BackgroundGradient) ^
+        SettingsHelper.CreateSetting(document, parent, "DisplayGameIcon", DisplayGameIcon) ^
+        SettingsHelper.CreateSetting(document, parent, "ShowRegion", ShowRegion) ^
+        SettingsHelper.CreateSetting(document, parent, "ShowPlatform", ShowPlatform) ^
+        SettingsHelper.CreateSetting(document, parent, "ShowVariables", ShowVariables) ^
+        SettingsHelper.CreateSetting(document, parent, "TextAlignment", (int)TextAlignment);
+    }
+
+    private void btnFont_Click(object sender, EventArgs e)
+    {
+        var dialog = SettingsHelper.GetFontDialog(TitleFont, 11, 26);
+        dialog.FontChanged += (s, ev) => TitleFont = ((CustomFontDialog.FontChangedEventArgs)ev).NewFont;
+        dialog.ShowDialog(this);
+        lblFont.Text = TitleFontString;
+    }
+
+    private void ColorButtonClick(object sender, EventArgs e)
+    {
+        SettingsHelper.ColorButtonClick((Button)sender, this);
     }
 }

--- a/src/LiveSplit.Title/UI/Components/TitleSettings.cs
+++ b/src/LiveSplit.Title/UI/Components/TitleSettings.cs
@@ -33,8 +33,8 @@ public partial class TitleSettings : UserControl
     public GradientType BackgroundGradient { get; set; }
     public string GradientString
     {
-        get { return BackgroundGradient.ToString(); }
-        set { BackgroundGradient = (GradientType)Enum.Parse(typeof(GradientType), value); }
+        get => BackgroundGradient.ToString();
+        set => BackgroundGradient = (GradientType)Enum.Parse(typeof(GradientType), value);
     }
 
     public TitleSettings()
@@ -161,7 +161,10 @@ public partial class TitleSettings : UserControl
         return parent;
     }
 
-    public int GetSettingsHashCode() => CreateSettingsNode(null, null);
+    public int GetSettingsHashCode()
+    {
+        return CreateSettingsNode(null, null);
+    }
 
     private int CreateSettingsNode(XmlDocument document, XmlElement parent)
     {

--- a/src/LiveSplit.Title/UI/Components/TitleSettings.cs
+++ b/src/LiveSplit.Title/UI/Components/TitleSettings.cs
@@ -125,13 +125,19 @@ public partial class TitleSettings : UserControl
                 else
                 {
                     if (DisplayGameIcon && SettingsHelper.ParseBool(element["CenterTitle"], false))
+                    {
                         TextAlignment = AlignmentType.Center;
+                    }
                     else
+                    {
                         TextAlignment = AlignmentType.Auto;
+                    }
                 }
             }
             else
+            {
                 OverrideTitleFont = !SettingsHelper.ParseBool(element["UseLayoutSettingsFont"]);
+            }
         }
         else
         {

--- a/src/LiveSplit.Title/UI/Components/TitleSettings.cs
+++ b/src/LiveSplit.Title/UI/Components/TitleSettings.cs
@@ -76,24 +76,24 @@ public partial class TitleSettings : UserControl
         chkVariables.DataBindings.Add("Checked", this, "ShowVariables", false, DataSourceUpdateMode.OnPropertyChanged);
     }
 
-    void TitleSettings_Load(object sender, EventArgs e)
+    private void TitleSettings_Load(object sender, EventArgs e)
     {
         chkColor_CheckedChanged(null, null);
         chkFont_CheckedChanged(null, null);
         cmbTextAlignment.SelectedIndex = (int)TextAlignment;
     }
 
-    void chkColor_CheckedChanged(object sender, EventArgs e)
+    private void chkColor_CheckedChanged(object sender, EventArgs e)
     {
         label3.Enabled = btnColor.Enabled = chkColor.Checked;
     }
 
-    void chkFont_CheckedChanged(object sender, EventArgs e)
+    private void chkFont_CheckedChanged(object sender, EventArgs e)
     {
         label1.Enabled = lblFont.Enabled = btnFont.Enabled = chkFont.Checked;
     }
 
-    void cmbGradientType_SelectedIndexChanged(object sender, EventArgs e)
+    private void cmbGradientType_SelectedIndexChanged(object sender, EventArgs e)
     {
         btnColor1.Visible = cmbGradientType.SelectedItem.ToString() != "Plain";
         btnColor2.DataBindings.Clear();
@@ -101,7 +101,7 @@ public partial class TitleSettings : UserControl
         GradientString = cmbGradientType.SelectedItem.ToString();
     }
 
-    void cmbTextAlignment_SelectedIndexChanged(object sender, EventArgs e)
+    private void cmbTextAlignment_SelectedIndexChanged(object sender, EventArgs e)
     {
         TextAlignment = (AlignmentType)cmbTextAlignment.SelectedIndex;
     }

--- a/src/LiveSplit.Title/UI/Components/TitleSettings.cs
+++ b/src/LiveSplit.Title/UI/Components/TitleSettings.cs
@@ -162,7 +162,7 @@ public partial class TitleSettings : UserControl
 
     public XmlNode GetSettings(XmlDocument document)
     {
-        var parent = document.CreateElement("Settings");
+        XmlElement parent = document.CreateElement("Settings");
         CreateSettingsNode(document, parent);
         return parent;
     }
@@ -196,7 +196,7 @@ public partial class TitleSettings : UserControl
 
     private void btnFont_Click(object sender, EventArgs e)
     {
-        var dialog = SettingsHelper.GetFontDialog(TitleFont, 11, 26);
+        CustomFontDialog.FontDialog dialog = SettingsHelper.GetFontDialog(TitleFont, 11, 26);
         dialog.FontChanged += (s, ev) => TitleFont = ((CustomFontDialog.FontChangedEventArgs)ev).NewFont;
         dialog.ShowDialog(this);
         lblFont.Text = TitleFontString;


### PR DESCRIPTION
Parent PR: https://github.com/LiveSplit/LiveSplit/pull/2533

### Description

* Introduces an `.editorconfig` file to enforce consistent style rules.
* Upgrades the language version to C# 12 (most recent stable).
* Adds `PolySharp` to allow for support of some language features which require runtime support (`Index` & `Range` operators).
* Fixes some warnings.
